### PR TITLE
Public access control: expose KBJWT initialiser

### DIFF
--- a/Sources/Issuer/JWT.swift
+++ b/Sources/Issuer/JWT.swift
@@ -26,7 +26,7 @@ public struct JWT: JWTRepresentable {
 
   // MARK: - Lifecycle
 
-  init(header: JWSHeader, payload: JSON) throws {
+  public init(header: JWSHeader, payload: JSON) throws {
     guard header.algorithm?.rawValue != Keys.none.rawValue else {
       throw SDJWTError.noneAsAlgorithm
     }
@@ -39,7 +39,7 @@ public struct JWT: JWTRepresentable {
     self.payload = payload
   }
 
-  init(header: JWSHeader, kbJwtPayload: JSON) throws {
+  public init(header: JWSHeader, kbJwtPayload: JSON) throws {
     guard header.algorithm?.rawValue != Keys.none.rawValue else {
       throw SDJWTError.noneAsAlgorithm
     }


### PR DESCRIPTION
# Description of change

Makes it possible to init KBJWT type. This is required for the presentation flow with key-binding JWT.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

N/A

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes