### PR TITLE
Public access control: SignedSDJWT recreate claims

### DIFF
--- a/Sources/Issuer/SDJWT.swift
+++ b/Sources/Issuer/SDJWT.swift
@@ -200,9 +200,10 @@ extension SignedSDJWT {
   func serialised(serialiser: (SignedSDJWT) -> (SerialiserProtocol)) throws -> String {
     serialiser(self).serialised
   }
+}
 
-  func recreateClaims() throws -> ClaimExtractorResult {
+extension SignedSDJWT {
+  public func recreateClaims() throws -> ClaimExtractorResult {
     return try self.toSDJWT().recreateClaims()
   }
-
 }


### PR DESCRIPTION
# Description of change

README.md specifies the functionality to recreate the claims in signed SD-JWT. However this function is marked as internal in the library and is therefore inaccessible to the library integrator. 

Makes the `recreateClaims()` func public.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

N/A

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes