### PR TITLE
Allow a client to configure/enable its preferred method of SD-JWT-VC signing key resolution.

### DIFF
--- a/Sources/Verifier/SDJWTVCVerifier.swift
+++ b/Sources/Verifier/SDJWTVCVerifier.swift
@@ -75,6 +75,49 @@ protocol SdJwtVcVerifierType {
     claimsVerifier: ClaimsVerifier,
     keyBindingVerifier: KeyBindingVerifier?
   ) async throws -> Result<SignedSDJWT, any Error>
+  
+  /**
+   * Creates a new verifier instance with SD-JWT-VC issuer metadata resolution enabled.
+   *
+   * - Parameter session: A `URLSession` instance used for HTTP communication.
+   * - Returns: An instance of the conforming type.
+   */
+  static func usingIssuerMetadata(
+    session: Networking
+  ) -> SdJwtVcVerifierType
+  
+  /**
+   * Creates a new verifier instance with X.509 certificate trust enabled.
+   *
+   * - Parameter x509CertificateTrust: The X.509 certificate trust configuration.
+   * - Returns: An instance of the conforming type.
+   */
+  static func usingX5c(
+    x509CertificateTrust: X509CertificateTrust
+  ) -> SdJwtVcVerifierType
+  
+  /**
+   * Creates a new verifier instance with DID resolution enabled.
+   *
+   * - Parameter didLookup: A service for looking up public keys from DID documents.
+   * - Returns: An instance of the conforming type.
+   */
+  static func usingDID(
+    didLookup: LookupPublicKeysFromDIDDocument
+  ) -> SdJwtVcVerifierType
+  
+  /**
+   * Creates a new verifier instance with both X.509 certificate trust and SD-JWT-VC issuer metadata resolution enabled.
+   *
+   * - Parameters:
+   *   - x509CertificateTrust: The X.509 certificate trust configuration.
+   *   - session: A `URLSession` instance used for HTTP communication.
+   * - Returns: An instance of the conforming type.
+   */
+  static func usingX5cOrIssuerMetadata(
+    x509CertificateTrust: X509CertificateTrust,
+    session: Networking
+  ) -> SdJwtVcVerifierType
 }
 
 /**
@@ -117,6 +160,40 @@ public class SDJWTVCVerifier: SdJwtVcVerifierType {
     self.fetcher = fetcher
     self.trust = trust
     self.lookup = lookup
+  }
+  
+  static func usingIssuerMetadata(
+    session: Networking
+  ) -> SdJwtVcVerifierType {
+    return SDJWTVCVerifier(
+      fetcher: SdJwtVcIssuerMetaDataFetcher(session: session)
+    )
+  }
+  
+  static func usingX5c(
+    x509CertificateTrust: X509CertificateTrust
+  ) -> SdJwtVcVerifierType {
+    return SDJWTVCVerifier(
+      trust: x509CertificateTrust
+    )
+  }
+  
+  static func usingDID(
+    didLookup: LookupPublicKeysFromDIDDocument
+  ) -> SdJwtVcVerifierType {
+    return SDJWTVCVerifier(
+      lookup: didLookup
+    )
+  }
+  
+  static func usingX5cOrIssuerMetadata(
+    x509CertificateTrust: X509CertificateTrust,
+    session: Networking
+  ) -> SdJwtVcVerifierType {
+    return SDJWTVCVerifier(
+      fetcher: SdJwtVcIssuerMetaDataFetcher(session: session),
+      trust: x509CertificateTrust
+    )
   }
   
   /**

--- a/Sources/Verifier/SDJWTVCVerifier.swift
+++ b/Sources/Verifier/SDJWTVCVerifier.swift
@@ -79,7 +79,7 @@ protocol SdJwtVcVerifierType {
   /**
    * Creates a new verifier instance with SD-JWT-VC issuer metadata resolution enabled.
    *
-   * - Parameter session: A `URLSession` instance used for HTTP communication.
+   * - Parameter session: A `Networking` instance used for HTTP communication.
    * - Returns: An instance of the conforming type.
    */
   static func usingIssuerMetadata(
@@ -111,7 +111,7 @@ protocol SdJwtVcVerifierType {
    *
    * - Parameters:
    *   - x509CertificateTrust: The X.509 certificate trust configuration.
-   *   - session: A `URLSession` instance used for HTTP communication.
+   *   - session: A `Networking` instance used for HTTP communication.
    * - Returns: An instance of the conforming type.
    */
   static func usingX5cOrIssuerMetadata(

--- a/Tests/Verification/VcVerifierTest.swift
+++ b/Tests/Verification/VcVerifierTest.swift
@@ -47,6 +47,22 @@ final class VcVerifierTest: XCTestCase {
     XCTAssertNoThrow(try result.get())
   }
   
+  func testVerifyIssuance_WithValidSDJWT_Withx509Header_AndConfiguration_ShouldSucceed() async throws {
+    
+    // Given
+    let sdJwtString = SDJWTConstants.x509_sd_jwt.clean()
+    
+    // When
+    let result = try await SDJWTVCVerifier.usingX5c(
+      x509CertificateTrust: X509CertificateChainVerifier()
+    ).verifyIssuance(
+      unverifiedSdJwt: sdJwtString
+    )
+    
+    // Then
+    XCTAssertNoThrow(try result.get())
+  }
+  
   func testVerifyIssuance_WithValidSDJWT_WithIssuerMetaData_ShouldSucceed() async throws {
     
     // Given
@@ -68,6 +84,25 @@ final class VcVerifierTest: XCTestCase {
     XCTAssertNoThrow(try result.get())
   }
   
+  func testVerifyIssuance_WithValidSDJWT_WithIssuerMetaData_AndConfiguration_ShouldSucceed() async throws {
+    
+    // Given
+    let sdJwtString = SDJWTConstants.issuer_metadata_sd_jwt.clean()
+    
+    // When
+    let result = try await SDJWTVCVerifier.usingIssuerMetadata(
+      session: NetworkingBundleMock(
+        path: "issuer_meta_data",
+        extension: "json"
+      )
+    ).verifyIssuance(
+      unverifiedSdJwt: sdJwtString
+    )
+    
+    // Then
+    XCTAssertNoThrow(try result.get())
+  }
+  
   func testVerifyIssuance_WithValidSDJWT_WithDID_ShouldSucceed() async throws {
     
     // Given
@@ -76,6 +111,22 @@ final class VcVerifierTest: XCTestCase {
     // When
     let result = try await SDJWTVCVerifier(
       lookup: LookupPublicKeysFromDIDDocumentMock()
+    ).verifyIssuance(
+      unverifiedSdJwt: sdJwtString
+    )
+    
+    // Then
+    XCTAssertNoThrow(try result.get())
+  }
+  
+  func testVerifyIssuance_WithValidSDJWT_WithDID_AndConfiguration_ShouldSucceed() async throws {
+    
+    // Given
+    let sdJwtString = SDJWTConstants.did_sd_jwt.clean()
+    
+    // When
+    let result = try await SDJWTVCVerifier.usingDID(
+      didLookup: LookupPublicKeysFromDIDDocumentMock()
     ).verifyIssuance(
       unverifiedSdJwt: sdJwtString
     )


### PR DESCRIPTION
# Description of change

There are 3 new factory methods that initialize an `SDJWTVCVerifier` for metadata, X509 certificates and DID.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes