### PR TITLE
SD-JWT-VC type metadata and claim path support

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,2 +1,4 @@
 identifier_name:
   allowed_symbols: [_]
+trailing_whitespace:
+  ignores_empty_lines: false

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8.1
+// swift-tools-version: 6.0.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ is implemented in Swift.
 ## Use cases supported
 
 - [Issuance](#issuance): As an Issuer use the library to issue a SD-JWT (in Combined Issuance Format)
-- [Holder Verification](#holder-verification): As Holder verify a SD-JWT (in Combined Issuance Format) issued by an
+- [Holder Verification](#holder-verification): As Holder verifies a SD-JWT (in Combined Issuance Format) issued by an
   Issuer
+- [Holder Presentation](#holder-presentation): As Holder creates a presentation
 - [Presentation Verification](#presentation-verification): As a Verifier verify SD-JWT in Combined Presentation Format or in Envelope Format 
 - [Recreate initial claims](#recreate-original-claims): Given a SD-JWT recreate the original claims
 * [SD-JWT VC support](#sd-jwt-vc-support)
@@ -82,6 +83,16 @@ SDJWTVerifier(parser: CompactParser(serialisedString: unverifiedSdJwtString))
     SignatureVerifier(signedJWT: jws, publicKey: issuersKeyPair.public)
 }
 ```
+
+## Holder Presentation
+
+In this case, a `Holder` of an SD-JWT issued by an `Issuer`, wants to create a presentation for a `Verifier`.
+The `Holder` should know which of the selectively disclosed claims to include in the presentation.
+The selectively disclosed claims to include in the presentation are expressed using Claim Paths as per 
+[SD-JWT VC draft 6](https://www.ietf.org/archive/id/draft-ietf-oauth-sd-jwt-vc-06.html#name-claim-path) or JSON Pointers.
+
+You can find comprehensive examples [here](Tests/EndToEnd/EndToEndTest.swift)
+
 ## Presentation Verification
 
 **In simple (not enveloped) format**

--- a/Sources/Digest/DigestCreator.swift
+++ b/Sources/Digest/DigestCreator.swift
@@ -15,7 +15,7 @@
  */
 import Foundation
 
-public class DigestCreator {
+public final class DigestCreator {
 
   // MARK: - Properties
 

--- a/Sources/Digest/HashingAlgorithm/SHA256.swift
+++ b/Sources/Digest/HashingAlgorithm/SHA256.swift
@@ -16,13 +16,13 @@
 import Foundation
 import CryptoKit
 
-public class SHA256Hashing: HashingAlgorithm {
+public final class SHA256Hashing: HashingAlgorithm {
 
   // MARK: - Properties
   public init() {
   }
 
-  public var identifier: String = "sha-256"
+  public let identifier: String = "sha-256"
 
   // MARK: - Methods
 

--- a/Sources/Digest/HashingAlgorithm/SHA384.swift
+++ b/Sources/Digest/HashingAlgorithm/SHA384.swift
@@ -16,11 +16,11 @@
 import Foundation
 import CryptoKit
 
-public class SHA384Hashing: HashingAlgorithm {
+public final class SHA384Hashing: HashingAlgorithm {
 
   // MARK: - Properties
 
-  public var identifier: String = "sha-384"
+  public let identifier: String = "sha-384"
 
   // MARK: - Methods
 

--- a/Sources/Digest/HashingAlgorithm/SHA512.swift
+++ b/Sources/Digest/HashingAlgorithm/SHA512.swift
@@ -16,11 +16,11 @@
 import Foundation
 import CryptoKit
 
-public class SHA512Hashing: HashingAlgorithm {
+public final class SHA512Hashing: HashingAlgorithm {
 
   // MARK: - Properties
 
-  public var identifier: String = "sha-512"
+  public let identifier: String = "sha-512"
 
   // MARK: - Methods
 

--- a/Sources/Digest/SaltProvider.swift
+++ b/Sources/Digest/SaltProvider.swift
@@ -22,7 +22,7 @@ protocol SaltProvider {
   var saltString: Salt { get }
 }
 
-class DefaultSaltProvider: SaltProvider {
+final class DefaultSaltProvider: SaltProvider {
 
   // MARK: - Properties
 

--- a/Sources/Fetchers/SdJwtVcIssuerMetaDataFetcher.swift
+++ b/Sources/Fetchers/SdJwtVcIssuerMetaDataFetcher.swift
@@ -65,8 +65,9 @@ public class SdJwtVcIssuerMetaDataFetcher: SdJwtVcIssuerMetaDataFetching {
 
 private extension SdJwtVcIssuerMetaDataFetcher {
   private func issuerMetadataUrl(for issuer: URL) -> URL {
+    let path = "/.well-known/jwt-vc-issuer"
     var components = URLComponents(url: issuer, resolvingAgainstBaseURL: false)!
-    components.path = "/.well-known/jwt-vc-issuer" + components.path
+    components.path = path + components.path
     return components.url!
   }
   

--- a/Sources/Issuer/SDJWT.swift
+++ b/Sources/Issuer/SDJWT.swift
@@ -54,7 +54,7 @@ public struct SDJWT {
     }
   }
   
-  func recreateClaims(visitor: Visitor? = nil) throws -> ClaimExtractorResult {
+  func recreateClaims(visitor: ClaimVisitor? = nil) throws -> ClaimExtractorResult {
     let digestCreator = try extractDigestCreator()
     var digestsOfDisclosuresDict = [DisclosureDigest: Disclosure]()
     for disclosure in self.disclosures {

--- a/Sources/Issuer/SignedSDJWT.swift
+++ b/Sources/Issuer/SignedSDJWT.swift
@@ -35,8 +35,7 @@ public struct SignedSDJWT {
     let separator = "~"
     let kbJwtSerialization = kbJwt?.compactSerialization ?? ""
     let jwtAndDisclosures: [String] = ([jwt.compactSerialization] + disclosures)
-    return
-    jwtAndDisclosures
+    return jwtAndDisclosures
       .reduce("") {
         $0.isEmpty ? $1 : $0 + separator + $1
       }

--- a/Sources/Matcher/Matcher.swift
+++ b/Sources/Matcher/Matcher.swift
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import SwiftyJSON
+
+/// A class that provides matching functionality for ClaimPath and JSON structures.
+public final class Matcher {
+  
+  /// The JSON structure against which matching is performed.
+  private let json: JSON
+  
+  /// Initializes the Matcher with a given JSON object.
+  /// - Parameter json: The JSON object to match against.
+  public init(json: JSON) {
+    self.json = json
+  }
+  
+  /// Checks if a given `ClaimPath` exists in the JSON structure.
+  /// - Parameter path: The `ClaimPath` to check.
+  /// - Returns: `true` if the path matches, `false` otherwise.
+  public func matches(_ path: ClaimPath) -> Bool {
+    return json.match(path) != nil
+  }
+  
+  /// Matches a `ClaimPath` against the JSON structure and returns the matched value.
+  /// - Parameter path: The `ClaimPath` to match.
+  /// - Returns: The matched `JSON` element if the path exists, `nil` otherwise.
+  public func match(_ path: ClaimPath) -> JSON? {
+    return json.match(path)
+  }
+}
+
+private extension JSON {
+  /// Matches a `ClaimPath` against the JSON and returns the matched value.
+  /// - Parameter path: The `ClaimPath` to match.
+  /// - Returns: The matched `JSON` element if the path exists, `nil` otherwise.
+  func match(_ path: ClaimPath) -> JSON? {
+    var currentJson: JSON = self
+    
+    for element in path.value {
+      switch element {
+      case .allArrayElements:
+        return currentJson.arrayValue.isEmpty ? nil : currentJson
+        
+      case .arrayElement(let index):
+        guard let arrayElement = currentJson.array?[safe: index] else {
+          return nil
+        }
+        currentJson = arrayElement
+        
+      case .claim(let name):
+        if currentJson[name].exists() {
+          currentJson = currentJson[name]
+        } else {
+          return nil
+        }
+      }
+    }
+    
+    return currentJson
+  }
+}
+

--- a/Sources/Types/SdJwtVcTypeMetadata.swift
+++ b/Sources/Types/SdJwtVcTypeMetadata.swift
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+import SwiftyJSON
+
+import Foundation
+import SwiftyJSON
+
+public struct SdJwtVcTypeMetadata {
+  public let vct: Vct
+  public let vctIntegrity: DocumentIntegrity?
+  public let name: String?
+  public let description: String?
+  public let extends: URL?
+  public let extendsIntegrity: DocumentIntegrity?
+  public let display: Display?
+  public let claims: [ClaimMetadata]?
+  public let schema: JSON?
+  public let schemaUri: URL?
+  public let schemaUriIntegrity: DocumentIntegrity?
+  
+  public init(
+    vct: Vct,
+    vctIntegrity: DocumentIntegrity? = nil,
+    name: String? = nil,
+    description: String? = nil,
+    extends: URL? = nil,
+    extendsIntegrity: DocumentIntegrity? = nil,
+    display: Display? = nil,
+    claims: [ClaimMetadata]? = nil,
+    schema: JSON? = nil,
+    schemaUri: URL? = nil,
+    schemaUriIntegrity: DocumentIntegrity? = nil
+  ) throws {
+    
+    guard schema == nil || schemaUri == nil else {
+      throw SDJWTError.error("Conflicting schema definitions")
+    }
+    
+    self.vct = vct
+    self.vctIntegrity = vctIntegrity
+    self.name = name
+    self.description = description
+    self.extends = extends
+    self.extendsIntegrity = extendsIntegrity
+    self.display = display
+    self.claims = claims
+    self.schema = schema
+    self.schemaUri = schemaUri
+    self.schemaUriIntegrity = schemaUriIntegrity
+  }
+
+  public struct Vct {
+    public let value: String
+    
+    public init(value: String) throws {
+      guard !value.isEmpty else {
+        throw SDJWTError.error("Vct value must not be blank")
+      }
+      self.value = value
+    }
+  }
+
+  public struct ClaimMetadata {
+    public let path: String
+    public let display: [ClaimDisplay]?
+    public let selectivelyDisclosable: ClaimSelectivelyDisclosable
+    public let svgId: String?
+    
+    public init(
+      path: String,
+      display: [ClaimDisplay]? = nil,
+      selectivelyDisclosable: ClaimSelectivelyDisclosable = .allowed,
+      svgId: String? = nil
+    ) {
+      self.path = path
+      self.display = display
+      self.selectivelyDisclosable = selectivelyDisclosable
+      self.svgId = svgId
+    }
+  }
+
+  public struct ClaimDisplay {
+    public let lang: String
+    public let label: String
+    public let description: String?
+    
+    public init(
+      lang: String,
+      label: String,
+      description: String? = nil
+    ) {
+      self.lang = lang
+      self.label = label
+      self.description = description
+    }
+  }
+
+  public enum ClaimSelectivelyDisclosable: String {
+    case always
+    case allowed
+    case never
+  }
+
+  public struct Display {
+    public let value: [DisplayMetadata]
+    
+    public init(value: [DisplayMetadata]) throws {
+      let uniqueLangs = Set(value.map { $0.lang })
+      guard value.count == uniqueLangs.count else {
+        throw SDJWTError.error("Each language must appear only once in the display list")
+      }
+      self.value = value
+    }
+  }
+
+  public struct DisplayMetadata {
+    public let lang: String
+    public let name: String
+    public let description: String?
+    public let rendering: RenderingMetadata?
+    
+    public init(
+      lang: String,
+      name: String,
+      description: String? = nil,
+      rendering: RenderingMetadata? = nil
+    ) {
+      self.lang = lang
+      self.name = name
+      self.description = description
+      self.rendering = rendering
+    }
+  }
+
+  public struct RenderingMetadata {
+    public let simple: SimpleRenderingMethod?
+    public let svgTemplates: [SvgTemplate]?
+    
+    public init(
+      simple: SimpleRenderingMethod? = nil,
+      svgTemplates: [SvgTemplate]? = nil
+    ) {
+      self.simple = simple
+      self.svgTemplates = svgTemplates
+    }
+  }
+
+  public struct SimpleRenderingMethod {
+    public let logo: LogoMetadata?
+    public let backgroundColor: String?
+    public let textColor: String?
+    
+    public init(
+      logo: LogoMetadata? = nil,
+      backgroundColor: String? = nil,
+      textColor: String? = nil
+    ) {
+      self.logo = logo
+      self.backgroundColor = backgroundColor
+      self.textColor = textColor
+    }
+  }
+
+  public struct SvgTemplate {
+    public let uri: URL
+    public let uriIntegrity: DocumentIntegrity?
+    public let properties: SvgTemplateProperties?
+    
+    public init(
+      uri: URL,
+      uriIntegrity: DocumentIntegrity? = nil,
+      properties: SvgTemplateProperties? = nil
+    ) {
+      self.uri = uri
+      self.uriIntegrity = uriIntegrity
+      self.properties = properties
+    }
+  }
+
+  public struct SvgTemplateProperties {
+    public let orientation: String?
+    public let colorScheme: String?
+    public let contrast: String?
+    
+    public init(
+      orientation: String? = nil,
+      colorScheme: String? = nil,
+      contrast: String? = nil
+    ) throws {
+      guard orientation != nil || colorScheme != nil || contrast != nil else {
+        throw SDJWTError.error("At least one property must be specified")
+      }
+      self.orientation = orientation
+      self.colorScheme = colorScheme
+      self.contrast = contrast
+    }
+  }
+
+  public struct LogoMetadata {
+    public let uri: URL
+    public let uriIntegrity: DocumentIntegrity?
+    public let altText: String?
+    
+    public init(
+      uri: URL,
+      uriIntegrity: DocumentIntegrity? = nil,
+      altText: String? = nil
+    ) {
+      self.uri = uri
+      self.uriIntegrity = uriIntegrity
+      self.altText = altText
+    }
+  }
+
+  public struct DocumentIntegrity {
+    public let value: String
+    
+    public init(value: String) {
+      self.value = value
+    }
+  }
+}

--- a/Sources/Types/Spec.swift
+++ b/Sources/Types/Spec.swift
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+
+/// Selective Disclosure for JWTs (SD-JWT)
+/// Reference: [SD-JWT Specification](https://datatracker.ietf.org/doc/draft-ietf-oauth-selective-disclosure-jwt/)
+struct SdJwtSpec {
+  /// Digests of Disclosures for object properties
+  static let claimSD = "_sd"
+  
+  /// Hash algorithm used to generate Disclosure digests and digest over presentation
+  static let claimSDAlg = "_sd_alg"
+  
+  /// Digest of the SD-JWT to which the KB-JWT is tied
+  static let claimSDHash = "sd_hash"
+  
+  /// Digest of the Disclosure for an array element
+  static let claimArrayElementDigest = "..."
+  
+  // MARK: - Header parameters for JWS JSON
+  /// An array of strings where each element is an individual Disclosure
+  static let jwsJSONDisclosures = "disclosures"
+  
+  /// Present only in an SD-JWT+KB, the Key Binding JWT
+  static let jwsJSONKBJWT = "kb_jwt"
+  
+  // MARK: - Other Constants
+  static let disclosureSeparator: Character = "~"
+  
+  // MARK: - Media Types
+  static let mediaSubtypeSDJWT = "sd-jwt"
+  static let mediaTypeApplicationSDJWT = "application/\(mediaSubtypeSDJWT)"
+  static let mediaSubtypeSDJWTJSON = "sd-jwt+json"
+  static let mediaTypeApplicationSDJWTJSON = "application/\(mediaSubtypeSDJWTJSON)"
+  static let mediaSubtypeKBJWT = "kb+jwt"
+  static let mediaTypeApplicationKBJWTJSON = "application/\(mediaSubtypeKBJWT)"
+  static let suffixSDJWT = "+sd-jwt"
+}
+
+/// JSON Web Signature (JWS) Specification
+/// Reference: [RFC 7515](https://datatracker.ietf.org/doc/html/rfc7515)
+struct RFC7515 {
+  static let jwsJSONHeader = "header"
+  static let jwsJSONProtected = "protected"
+  static let jwsJSONSignature = "signature"
+  static let jwsJSONSignatures = "signatures"
+  static let jwsJSONPayload = "payload"
+}
+
+/// SD-JWT-based Verifiable Credentials Specification
+/// Reference: [SD-JWT-VC](https://datatracker.ietf.org/doc/draft-ietf-oauth-sd-jwt-vc/)
+struct SdJwtVcSpec {
+  static let wellKnownSuffixJWTVcIssuer = "jwt-vc-issuer"
+  static let wellKnownJWTVcIssuer = "/.well-known/\(wellKnownSuffixJWTVcIssuer)"
+  
+  /// Deprecated: Removed from SD-JWT-VC
+  @available(*, deprecated, message: "Replaced with SdJwtVcSpec.mediaSubtypeDCSdJWT")
+  static let mediaSubtypeVCSdJWT = "vc+sd-jwt"
+  
+  // MARK: - Media Types
+  static let mediaSubtypeDCSdJWT = "dc+sd-jwt"
+  static let mediaTypeApplicationDCSdJWT = "application/\(mediaSubtypeDCSdJWT)"
+  
+  // MARK: - Issuer Metadata
+  static let issuer = "issuer"
+  
+  // MARK: - Type Metadata
+  static let hashIntegrity = "#integrity"
+  static let vct = "vct"
+  static let vctIntegrity = "\(vct)\(hashIntegrity)"
+  static let name = "name"
+  static let description = "description"
+  static let extends = "extends"
+  static let extendsIntegrity = "\(extends)\(hashIntegrity)"
+  static let display = "display"
+  static let claims = "claims"
+  static let schema = "schema"
+  static let schemaURI = "schema_uri"
+  static let schemaURIIntegrity = "\(schemaURI)\(hashIntegrity)"
+  static let claimPath = "path"
+  static let claimDisplay = "display"
+  static let claimSD = "sd"
+  static let claimSDAlways = "always"
+  static let claimSDAllowed = "allowed"
+  static let claimSDNever = "never"
+  static let claimSVGID = "svg_id"
+  static let claimLang = "lang"
+  static let claimLabel = "label"
+  static let claimDescription = description
+  static let lang = "lang"
+  static let rendering = "rendering"
+  static let simple = "simple"
+  static let svgTemplates = "svg_templates"
+  static let logo = "logo"
+  static let logoURI = "uri"
+  static let logoURIIntegrity = "\(logoURI)\(hashIntegrity)"
+  static let logoAltText = "alt_text"
+  static let backgroundColor = "background_color"
+  static let textColor = "text_color"
+  static let svgURI = "uri"
+  static let svgURIIntegrity = "\(svgURI)\(hashIntegrity)"
+  static let svgProperties = "properties"
+  static let svgOrientation = "orientation"
+  static let svgOrientationPortrait = "portrait"
+  static let svgOrientationLandscape = "landscape"
+  static let svgColorScheme = "color_scheme"
+  static let svgColorSchemeLight = "light"
+  static let svgColorSchemeDark = "dark"
+  static let svgContrast = "contrast"
+  static let svgContrastNormal = "normal"
+  static let svgContrastHigh = "high"
+}
+
+/// JSON Web Token (JWT) Specification
+/// Reference: [RFC 7519](https://datatracker.ietf.org/doc/html/rfc7519)
+struct RFC7519 {
+  static let issuer = "iss"
+  static let subject = "sub"
+  static let audience = "aud"
+  static let expirationTime = "exp"
+  static let notBefore = "nbf"
+  static let issuedAt = "iat"
+  static let jwtID = "jti"
+}

--- a/Sources/Types/Types.swift
+++ b/Sources/Types/Types.swift
@@ -19,7 +19,7 @@ public typealias KeyPair = (public: SecKey, private: SecKey)
 public typealias JWTString = String
 public typealias Nonce = String
 
-public enum SDJWTError: Error {
+public enum SDJWTError: Error, Equatable {
   case sdAsKey
   case nullJSONValue
   case encodingError
@@ -30,6 +30,7 @@ public enum SDJWTError: Error {
   case algorithmMissMatch
   case noneAsAlgorithm
   case macAsAlgorithm
+  case error(String)
 }
 
 public enum SDJWTVerifierError: Error {

--- a/Sources/Utilities/ClaimPath.swift
+++ b/Sources/Utilities/ClaimPath.swift
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+import SwiftyJSON
+
+/// A structure representing a path in a hierarchical claim structure.
+public struct ClaimPath: Equatable, Hashable {
+  /// The list of elements representing the path.
+  public let value: [ClaimPathElement]
+  
+  /// Initializes a `ClaimPath` ensuring it is not empty.
+  /// - Parameter value: An array of `ClaimPathElement` representing the path.
+  public init(_ value: [ClaimPathElement]) {
+    precondition(!value.isEmpty, "ClaimPath cannot be empty")
+    self.value = value
+  }
+  
+  /// Returns a string representation of the claim path.
+  public var description: String {
+    return value.description
+  }
+  
+  /// Appends a `ClaimPathElement` to the current path.
+  public static func + (lhs: ClaimPath, rhs: ClaimPathElement) -> ClaimPath {
+    return ClaimPath(lhs.value + [rhs])
+  }
+  
+  /// Merges two `ClaimPath` instances into a single path.
+  public static func + (lhs: ClaimPath, rhs: ClaimPath) -> ClaimPath {
+    return ClaimPath(lhs.value + rhs.value)
+  }
+  
+  /// Checks if the current path contains another path.
+  /// - Parameter that: The `ClaimPath` to compare against.
+  /// - Returns: `true` if `that` is contained within `self`, otherwise `false`.
+  public func contains(_ that: ClaimPath) -> Bool {
+    guard self.value.count <= that.value.count else { return false }
+    return self.value.enumerated().allSatisfy { index, element in
+      guard index < that.value.count else { return false }
+      return element.contains(that.value[index])
+    }
+  }
+  
+  /// Appends a wild-card indicator (`ClaimPathElement.allArrayElements`).
+  public func allArrayElements() -> ClaimPath {
+    return self + .allArrayElements
+  }
+  
+  /// Appends an indexed path (`ClaimPathElement.arrayElement`).
+  public func arrayElement(_ index: Int) -> ClaimPath {
+    return self + .arrayElement(index: index)
+  }
+  
+  /// Appends a named path (`ClaimPathElement.claim`).
+  public func claim(_ name: String) -> ClaimPath {
+    return self + .claim(name: name)
+  }
+  
+  /// Retrieves the parent path of the current `ClaimPath`.
+  /// - Returns: The parent `ClaimPath` if it exists, otherwise `nil`.
+  public func parent() -> ClaimPath? {
+    guard !value.isEmpty else { return nil }
+    let newValue = Array(value.dropLast())
+    return newValue.isEmpty ? nil : ClaimPath(newValue)
+  }
+  
+  /// Retrieves the first element of the claim path.
+  public func head() -> ClaimPathElement {
+    return value.first!
+  }
+  
+  /// Retrieves the tail of the claim path (all elements except the first).
+  /// - Returns: A new `ClaimPath` without the first element, or `nil` if empty.
+  public func tail() -> ClaimPath? {
+    let tailElements = Array(value.dropFirst())
+    return tailElements.isEmpty ? nil : ClaimPath(tailElements)
+  }
+  
+  /// Retrieves the head element.
+  public func component1() -> ClaimPathElement {
+    return head()
+  }
+  
+  /// Retrieves the tail path.
+  public func component2() -> ClaimPath? {
+    return tail()
+  }
+  
+  /// Creates a `ClaimPath` from a single claim name.
+  /// - Parameter name: The name of the claim.
+  /// - Returns: A `ClaimPath` containing a single `ClaimPathElement.claim`.
+  public static func claim(_ name: String) -> ClaimPath {
+    return ClaimPath([.claim(name: name)])
+  }
+}
+
+public enum ClaimPathElement: Equatable, Hashable {
+  /// Indicates that all elements of the currently selected array(s) are to be selected.
+  /// It is represented as `nil` when serialized.
+  case allArrayElements
+  
+  /// Indicates that a specific index in an array is to be selected.
+  /// The index must be non-negative.
+  case arrayElement(index: Int)
+  
+  /// Indicates that a specific key is to be selected.
+  /// The key is represented as a string.
+  case claim(name: String)
+  
+  /// Checks whether the current instance contains the other.
+  public func contains(_ other: ClaimPathElement) -> Bool {
+    switch (self, other) {
+    case (.allArrayElements, .allArrayElements): return true
+    case (.allArrayElements, .arrayElement): return true
+    case (.allArrayElements, .claim): return false
+    case (.arrayElement(let index1), .arrayElement(let index2)): return index1 == index2
+    case (.claim(let name1), .claim(let name2)): return name1 == name2
+    default: return false
+    }
+  }
+  
+  /// Returns a string representation of the element.
+  public var description: String {
+    switch self {
+    case .allArrayElements: return "null"
+    case .arrayElement(let index): return "\(index)"
+    case .claim(let name): return name
+    }
+  }
+  
+  /// Helper function to apply different closures based on the case.
+  public func fold<T>(
+    ifAllArrayElements: () -> T,
+    ifArrayElement: (Int) -> T,
+    ifClaim: (String) -> T
+  ) -> T {
+    switch self {
+    case .allArrayElements: return ifAllArrayElements()
+    case .arrayElement(let index): return ifArrayElement(index)
+    case .claim(let name): return ifClaim(name)
+    }
+  }
+}
+
+extension ClaimPath: Decodable {
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    let jsonArray = try container.decode([JSON].self)
+    
+    let elements = try jsonArray.map { json in
+      if let intValue = json.int {
+        return ClaimPathElement.arrayElement(index: intValue)
+      } else if json.null != nil {
+        return ClaimPathElement.allArrayElements
+      } else if let stringValue = json.string {
+        return ClaimPathElement.claim(name: stringValue)
+      } else {
+        throw DecodingError.dataCorruptedError(
+          in: container,
+          debugDescription: "Invalid ClaimPathElement type"
+        )
+      }
+    }
+    
+    self.init(elements)
+  }
+}

--- a/Sources/Utilities/ClaimPath.swift
+++ b/Sources/Utilities/ClaimPath.swift
@@ -16,15 +16,20 @@
 import Foundation
 import SwiftyJSON
 
+public enum ClaimPathError: Error {
+  case emptyClaimPath
+  case invalidJsonPointerFormat(String)
+  case elementNotFound(ClaimPath)
+}
+
 /// A structure representing a path in a hierarchical claim structure.
-public struct ClaimPath: Equatable, Hashable {
+public struct ClaimPath: Equatable, Hashable, Sendable {
   /// The list of elements representing the path.
   public let value: [ClaimPathElement]
   
   /// Initializes a `ClaimPath` ensuring it is not empty.
   /// - Parameter value: An array of `ClaimPathElement` representing the path.
   public init(_ value: [ClaimPathElement]) {
-    precondition(!value.isEmpty, "ClaimPath cannot be empty")
     self.value = value
   }
   
@@ -106,7 +111,7 @@ public struct ClaimPath: Equatable, Hashable {
   }
 }
 
-public enum ClaimPathElement: Equatable, Hashable {
+public enum ClaimPathElement: Equatable, Hashable, Sendable {
   /// Indicates that all elements of the currently selected array(s) are to be selected.
   /// It is represented as `nil` when serialized.
   case allArrayElements

--- a/Sources/Utilities/ClaimPath.swift
+++ b/Sources/Utilities/ClaimPath.swift
@@ -47,10 +47,9 @@ public struct ClaimPath: Equatable, Hashable {
   /// - Parameter that: The `ClaimPath` to compare against.
   /// - Returns: `true` if `that` is contained within `self`, otherwise `false`.
   public func contains(_ that: ClaimPath) -> Bool {
-    guard self.value.count <= that.value.count else { return false }
-    return self.value.enumerated().allSatisfy { index, element in
-      guard index < that.value.count else { return false }
-      return element.contains(that.value[index])
+    guard that.value.count <= self.value.count else { return false }
+    return zip(self.value, that.value).allSatisfy { (selfElement, thatElement) in
+      selfElement.contains(thatElement)
     }
   }
   

--- a/Sources/Utilities/Extensions/Array+Extension.swift
+++ b/Sources/Utilities/Extensions/Array+Extension.swift
@@ -15,6 +15,13 @@
  */
 
 extension Array {
+  /// Safely accesses an element at the given index.
+  /// - Parameter index: The index to access.
+  /// - Returns: The element if within bounds, otherwise `nil`.
+  subscript(safe index: Int) -> Element? {
+      return indices.contains(index) ? self[index] : nil
+  }
+  
   mutating func appendOptional(_ newElement: Element? ) {
     guard let newElement else {
       return
@@ -24,13 +31,13 @@ extension Array {
 }
 
 extension Array {
-    subscript(safe range: Range<Index>) -> [Element]? {
-        if range.lowerBound >= startIndex && range.upperBound <= endIndex {
-            return Array(self[range])
-        } else {
-            return nil
-        }
+  subscript(safe range: Range<Index>) -> [Element]? {
+    if range.lowerBound >= startIndex && range.upperBound <= endIndex {
+      return Array(self[range])
+    } else {
+      return nil
     }
+  }
 }
 
 extension Array where Element == String {

--- a/Sources/Utilities/Extensions/ClaimPath+Extensions.swift
+++ b/Sources/Utilities/Extensions/ClaimPath+Extensions.swift
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import SwiftyJSON
+
+extension ClaimPath {
+  /// Checks if the `ClaimPath` exists in the JSON structure.
+  /// - Parameter json: The JSON element to check.
+  /// - Returns: `true` if the path matches, `false` otherwise.
+  func matches(json: JSON) -> Bool {
+    return match(json: json) != nil
+  }
+  
+  /// Matches the `ClaimPath` against a JSON element and returns the matched value.
+  /// - Parameter json: The JSON element to match against.
+  /// - Returns: The matched `JSON` element if the path exists, `nil` otherwise.
+  func match(json: JSON) -> JSON? {
+    var currentJson: JSON = json
+    
+    for element in value {
+      switch element {
+      case .allArrayElements:
+        // If it's an array, return it. Otherwise, return nil.
+        return currentJson.arrayValue.isEmpty ? nil : currentJson
+        
+      case .arrayElement(let index):
+        // If it's an array and index exists, continue. Otherwise, return nil.
+        guard let arrayElement = currentJson.array?[safe: index] else {
+          return nil
+        }
+        currentJson = arrayElement
+        
+      case .claim(let name):
+        // If it's a dictionary and key exists, continue. Otherwise, return nil.
+        if currentJson[name].exists() {
+          currentJson = currentJson[name]
+        } else {
+          return nil
+        }
+      }
+    }
+    
+    return currentJson // Return the matched JSON element
+  }
+}
+
+

--- a/Sources/Utilities/Extensions/JSON+Extension.swift
+++ b/Sources/Utilities/Extensions/JSON+Extension.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import SwiftyJSON
+@preconcurrency import SwiftyJSON
 
 extension JSON {
   subscript(key: Keys) -> JSON {

--- a/Sources/Utilities/SelectPath.swift
+++ b/Sources/Utilities/SelectPath.swift
@@ -65,10 +65,3 @@ struct DefaultSelectPath: SelectPath {
     }
   }
 }
-
-// Safe array indexing extension
-private extension Array {
-  subscript(safe index: Int) -> Element? {
-    return indices.contains(index) ? self[index] : nil
-  }
-}

--- a/Sources/Utilities/SelectPath.swift
+++ b/Sources/Utilities/SelectPath.swift
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+import SwiftyJSON
+
+/// Protocol for selecting a JSON path.
+protocol SelectPath {
+  /// Matches the given path to the JSON.
+  /// - Parameters:
+  ///   - json: The JSON to match against.
+  ///   - path: The claim path to match.
+  /// - Returns: A JSON element if found, otherwise an error.
+  func select(json: JSON, path: ClaimPath) -> Result<JSON?, Error>
+}
+
+/// Default implementation of `SelectPath`.
+struct DefaultSelectPath: SelectPath {
+  func select(json: JSON, path: ClaimPath) -> Result<JSON?, Error> {
+    do {
+      return .success(try selectPath(json: json, path: path))
+    } catch {
+      return .failure(error)
+    }
+  }
+  
+  /// Helper function to recursively traverse the JSON structure.
+  private func selectPath(json: JSON, path: ClaimPath) throws -> JSON? {
+    guard let head = path.value.first else { return nil }
+    let tail = path.tail()
+    
+    switch head {
+    case .claim(let name):
+      guard json.dictionary != nil else {
+        throw NSError(domain: "SelectPath", code: 1, userInfo: [NSLocalizedDescriptionKey: "Expected JSON object, found \(json)"])
+      }
+      let selectedElement = json[name]
+      return tail == nil ? selectedElement : try selectPath(json: selectedElement, path: tail!)
+      
+    case .arrayElement(let index):
+      guard json.array != nil else {
+        throw NSError(domain: "SelectPath", code: 2, userInfo: [NSLocalizedDescriptionKey: "Expected JSON array, found \(json)"])
+      }
+      let selectedElement = json.arrayValue[safe: index]
+      return tail == nil ? selectedElement : try selectPath(json: selectedElement ?? JSON.null, path: tail!)
+      
+    case .allArrayElements:
+      guard let jsonArray = json.array else {
+        throw NSError(domain: "SelectPath", code: 3, userInfo: [NSLocalizedDescriptionKey: "Expected JSON array, found \(json)"])
+      }
+      let selectedElements = jsonArray.compactMap { try? selectPath(json: $0, path: tail!) }
+      return JSON(selectedElements)
+    }
+  }
+}
+
+// Safe array indexing extension
+private extension Array {
+  subscript(safe index: Int) -> Element? {
+    return indices.contains(index) ? self[index] : nil
+  }
+}

--- a/Sources/Verifier/ClaimsVerifier.swift
+++ b/Sources/Verifier/ClaimsVerifier.swift
@@ -16,7 +16,7 @@
 import Foundation
 import SwiftyJSON
 
-public class ClaimsVerifier: VerifierProtocol {
+public final class ClaimsVerifier: VerifierProtocol {
   
   // MARK: - Properties
   let iat: Date?

--- a/Sources/Verifier/KeyBindingVerifier.swift
+++ b/Sources/Verifier/KeyBindingVerifier.swift
@@ -51,7 +51,7 @@ public final class KeyBindingVerifier: VerifierProtocol {
     
     self.signatureVerifier = try SignatureVerifier(signedJWT: challenge, publicKey: extractedKey)
     
-    try verifyIat(iatOffset: iatOffset, iat: Date(timeIntervalSince1970: TimeInterval(timeInterval)))
+    try verifyIat(iatOffset: iatOffset, iat: Date())
     try verifyAud(aud: aud, expectedAudience: expectedAudience)
     
     try verify()

--- a/Sources/Verifier/KeyBindingVerifier.swift
+++ b/Sources/Verifier/KeyBindingVerifier.swift
@@ -18,7 +18,7 @@ import JSONWebKey
 import JSONWebSignature
 import SwiftyJSON
 
-public class KeyBindingVerifier: VerifierProtocol {
+public final class KeyBindingVerifier: VerifierProtocol {
   
   static let kbJwt = "kb+jwt"
   

--- a/Sources/Verifier/SDJWTVCVerifier.swift
+++ b/Sources/Verifier/SDJWTVCVerifier.swift
@@ -435,7 +435,8 @@ private extension SDJWTVCVerifier {
       )
     } else if issScheme == HTTPS_URI_SCHEME {
       guard
-        let issUrl = issUrl
+        let issUrl = issUrl,
+        isIssuerFQDNContained(in: leaf, issuerUrl: issUrl) || isIssuerURIContained(in: leaf, iss: iss)
       else {
         return nil
       }

--- a/Sources/Verifier/X509CertificateChainVerifier.swift
+++ b/Sources/Verifier/X509CertificateChainVerifier.swift
@@ -18,7 +18,7 @@ import X509
 import SwiftASN1
 import Security
 
-public protocol X509CertificateTrust {
+public protocol X509CertificateTrust: Sendable {
   func isTrusted(chain: [Certificate]) async -> Bool
 }
 

--- a/Tests/EndToEnd/EndToEndTest.swift
+++ b/Tests/EndToEnd/EndToEndTest.swift
@@ -35,9 +35,9 @@ final class EndToEndTest: XCTestCase {
   func testEndToEndWithPrimaryIssuerSdJWT() async throws {
     
     // Given
-    let visitor = Visitor()
+    let visitor = ClaimVisitor()
     let verifier: KeyBindingVerifier = KeyBindingVerifier()
-    let sdJwtString = SDJWTConstants.primary_issuer_sd_jwt.clean()
+    let sdJwtString = SDJWTConstants.secondary_issuer_sd_jwt.clean()
     let query: Set<JSONPointer> = Set(
       [
         "/family_name",
@@ -114,7 +114,7 @@ final class EndToEndTest: XCTestCase {
   func testEndToEndWithSecondaryIssuerSdJWT() async throws {
     
     // Given
-    let visitor = Visitor()
+    let visitor = ClaimVisitor()
     let verifier: KeyBindingVerifier = KeyBindingVerifier()
     let sdJwtString = SDJWTConstants.secondary_issuer_sd_jwt.clean()
     let query: Set<JSONPointer> = Set(

--- a/Tests/EndToEnd/EndToEndTest.swift
+++ b/Tests/EndToEnd/EndToEndTest.swift
@@ -73,10 +73,12 @@ final class EndToEndTest: XCTestCase {
     var holderPresentation: SignedSDJWT?
     holderPresentation = try await SDJWTIssuer
       .presentation(
-        holdersPrivateKey: TestP256AsyncSigner(secKey: holdersKeyPair.private),
+        holdersPrivateKey: TestP256AsyncSigner(
+          secKey: holdersKeyPair.private
+        ),
         signedSDJWT: issuerSignedSDJWT,
         disclosuresToPresent: presentedSdJwt!.disclosures,
-        keyBindingJWT: KBJWT(
+        keyBindingJWT: .init(
           header: DefaultJWSHeaderImpl(algorithm: .ES256),
           kbJwtPayload: .init([
             Keys.nonce.rawValue: "123456789",

--- a/Tests/EndToEnd/EndToEndTest.swift
+++ b/Tests/EndToEnd/EndToEndTest.swift
@@ -70,6 +70,8 @@ final class EndToEndTest: XCTestCase {
         ).serialised
       )!
     
+    let aud = "example.com"
+    let timestamp = Int(Date().timeIntervalSince1970.rounded())
     var holderPresentation: SignedSDJWT?
     holderPresentation = try await SDJWTIssuer
       .presentation(
@@ -82,8 +84,8 @@ final class EndToEndTest: XCTestCase {
           header: DefaultJWSHeaderImpl(algorithm: .ES256),
           kbJwtPayload: .init([
             Keys.nonce.rawValue: "123456789",
-            Keys.aud.rawValue: "example.com",
-            Keys.iat.rawValue: 1694600000,
+            Keys.aud.rawValue: aud,
+            Keys.iat.rawValue: timestamp,
             Keys.sdHash.rawValue: sdHash
           ])
         )
@@ -96,8 +98,8 @@ final class EndToEndTest: XCTestCase {
     XCTAssertNoThrow(
       try verifier.verify(
         iatOffset: .init(
-          startTime: Date(timeIntervalSince1970: 1694600000 - 1000),
-          endTime: Date(timeIntervalSince1970: 1694600000)
+          startTime: Date(timeIntervalSinceNow: -100000),
+          endTime: Date(timeIntervalSinceNow: 100000)
         )!,
         expectedAudience: "example.com",
         challenge: kbJwt!,
@@ -175,8 +177,8 @@ final class EndToEndTest: XCTestCase {
     XCTAssertNoThrow(
       try verifier.verify(
         iatOffset: .init(
-          startTime: Date(timeIntervalSince1970: 1694600000 - 1000),
-          endTime: Date(timeIntervalSince1970: 1694600000)
+          startTime: Date(timeIntervalSinceNow: -100000),
+          endTime: Date(timeIntervalSinceNow: 100000)
         )!,
         expectedAudience: "example.com",
         challenge: kbJwt!,

--- a/Tests/Helpers/Constants.swift
+++ b/Tests/Helpers/Constants.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Foundation
+@preconcurrency import Foundation
 
 let key =
   """
@@ -25,10 +25,11 @@ let key =
   }
   """
   .clean()
+
 // Key Pairs Used in the examples
 let holdersKeyPair = generateES256KeyPair()
 
-let issuersKeyPair = generateES256KeyPair()
+nonisolated(unsafe) let issuersKeyPair = generateES256KeyPair()
 
 struct SDJWTConstants {
   

--- a/Tests/Issuance/DecoyTest.swift
+++ b/Tests/Issuance/DecoyTest.swift
@@ -47,9 +47,6 @@ final class DecoyTest: XCTestCase {
       }
     }
 
-    let asJSON = alrtSdObject.asJSON
-    let asObject = alrtSdObject.asObject
-
     let jwtFactory = SDJWTFactory(decoysLimit: decoysLimit)
     let unsignedJwt = jwtFactory.createSDJWTPayload(sdJwtObject: sdObject.asObject)
 

--- a/Tests/Matcher/MatcherTests.swift
+++ b/Tests/Matcher/MatcherTests.swift
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import XCTest
+import SwiftyJSON
+
+@testable import eudi_lib_sdjwt_swift
+
+final class MatcherTests: XCTestCase {
+  
+  var json: JSON!
+  var matcher: Matcher!
+  
+  override func setUp() {
+    super.setUp()
+    
+    // Sample JSON structure
+    json = JSON([
+      "user": [
+        "name": "John Doe",
+        "age": 30,
+        "address": [
+          "city": "New York",
+          "zip": "10001"
+        ]
+      ],
+      "items": [
+        ["name": "Item 1", "price": 10],
+        ["name": "Item 2", "price": 20],
+        ["name": "Item 3", "price": 30]
+      ],
+      "config": [
+        "enabled": true,
+        "thresholds": [100, 200, 300]
+      ]
+    ])
+    
+    matcher = Matcher(json: json)
+  }
+  
+  // MARK: - Basic Matching Tests
+  
+  func testMatchSingleLevelKey() {
+    let path = ClaimPath.claim("user")
+    let result = matcher.match(path)
+    XCTAssertNotNil(result)
+    XCTAssertEqual(result?["name"].stringValue, "John Doe")
+  }
+  
+  func testMatchNestedKey() {
+    let path = ClaimPath([.claim(name: "user"), .claim(name: "name")])
+    let result = matcher.match(path)
+    XCTAssertEqual(result?.stringValue, "John Doe")
+  }
+  
+  func testMatchDeeplyNestedKey() {
+    let path = ClaimPath([.claim(name: "user"), .claim(name: "address"), .claim(name: "city")])
+    let result = matcher.match(path)
+    XCTAssertEqual(result?.stringValue, "New York")
+  }
+  
+  // MARK: - Array Indexing Tests
+  
+  func testMatchArrayElement() {
+    let path = ClaimPath([.claim(name: "items"), .arrayElement(index: 1), .claim(name: "name")])
+    let result = matcher.match(path)
+    XCTAssertEqual(result?.stringValue, "Item 2")
+  }
+  
+  func testMatchOutOfBoundsArrayElement() {
+    let path = ClaimPath([.claim(name: "items"), .arrayElement(index: 10)])
+    let result = matcher.match(path)
+    XCTAssertNil(result)
+  }
+  
+  func testMatchArrayAllElements() {
+    let path = ClaimPath([.claim(name: "items"), .allArrayElements])
+    let result = matcher.match(path)
+    XCTAssertNotNil(result)
+    XCTAssertEqual(result?.arrayValue.count, 3)
+  }
+  
+  // MARK: - Non-existent Keys
+  
+  func testMatchNonExistentKey() {
+    let path = ClaimPath([.claim(name: "invalidKey")])
+    let result = matcher.match(path)
+    XCTAssertNil(result)
+  }
+  
+  func testMatchPartialInvalidPath() {
+    let path = ClaimPath([.claim(name: "user"), .claim(name: "invalidKey")])
+    let result = matcher.match(path)
+    XCTAssertNil(result)
+  }
+  
+  // MARK: - Boolean Matching Tests
+  
+  func testMatchesReturnsTrueForExistingPath() {
+    let path = ClaimPath([.claim(name: "user"), .claim(name: "name")])
+    XCTAssertTrue(matcher.matches(path))
+  }
+  
+  func testMatchesReturnsFalseForNonExistentPath() {
+    let path = ClaimPath([.claim(name: "user"), .claim(name: "invalidKey")])
+    XCTAssertFalse(matcher.matches(path))
+  }
+  
+  // MARK: - Edge Cases
+  
+  func testMatchEmptyClaimPath() {
+    let path = ClaimPath([])
+    let result = matcher.match(path)
+    XCTAssertNil(result)
+  }
+  
+  func testMatchRoot() {
+    let path = ClaimPath([.claim(name: "")])
+    let result = matcher.match(path)
+    XCTAssertNotNil(result)
+  }
+  
+  func testMatchBooleanValue() {
+    let path = ClaimPath([.claim(name: "config"), .claim(name: "enabled")])
+    let result = matcher.match(path)
+    XCTAssertEqual(result?.boolValue, true)
+  }
+  
+  func testMatchNumberArrayElement() {
+    let path = ClaimPath([.claim(name: "config"), .claim(name: "thresholds"), .arrayElement(index: 1)])
+    let result = matcher.match(path)
+    XCTAssertEqual(result?.intValue, 200)
+  }
+  
+  func testMatchWholeArray() {
+    let path = ClaimPath([.claim(name: "config"), .claim(name: "thresholds")])
+    let result = matcher.match(path)
+    XCTAssertNotNil(result)
+    XCTAssertEqual(result?.arrayValue.count, 3)
+  }
+  
+  // MARK: - Invalid Path Formats
+  
+  func testMatchWithInvalidJsonPointerPath() {
+    let path = ClaimPath(jsonPointer: "invalid-path")
+    XCTAssertNil(path)
+  }
+  
+  func testMatchWithMalformedPath() {
+    let path = ClaimPath([.claim(name: "/wrong/format")])
+    let result = matcher.match(path)
+    XCTAssertNil(result)
+  }
+  
+  func testMatchWithEscapedCharacters() {
+    let path = ClaimPath([.claim(name: "user/name")])
+    let result = matcher.match(path)
+    XCTAssertNil(result)
+  }
+  
+  func testMatchWithNestedArray() {
+    let nestedJson: JSON = [
+      "data": [
+        "records": [
+          ["id": 1, "value": "A"],
+          ["id": 2, "value": "B"],
+          ["id": 3, "value": "C"]
+        ]
+      ]
+    ]
+    
+    let nestedMatcher = Matcher(json: nestedJson)
+    let path = ClaimPath([.claim(name: "data"), .claim(name: "records"), .arrayElement(index: 2), .claim(name: "value")])
+    let result = nestedMatcher.match(path)
+    XCTAssertEqual(result?.stringValue, "C")
+  }
+}

--- a/Tests/Matcher/MatcherTests.swift
+++ b/Tests/Matcher/MatcherTests.swift
@@ -41,6 +41,11 @@ final class MatcherTests: XCTestCase {
         ["name": "Item 2", "price": 20],
         ["name": "Item 3", "price": 30]
       ],
+      "things": [
+        "one",
+        "two",
+        "three"
+      ],
       "config": [
         "enabled": true,
         "thresholds": [100, 200, 300]
@@ -92,6 +97,13 @@ final class MatcherTests: XCTestCase {
     XCTAssertEqual(result?.arrayValue.count, 3)
   }
   
+  func testMatchArrayAllElementsReturned() {
+    let path = ClaimPath([.claim(name: "items"), .allArrayElements, .claim(name: "price")])
+    let result = matcher.match(path)
+    XCTAssertNotNil(result)
+    XCTAssertEqual(result?.arrayValue, [10, 20, 30])
+  }
+  
   // MARK: - Non-existent Keys
   
   func testMatchNonExistentKey() {
@@ -123,13 +135,13 @@ final class MatcherTests: XCTestCase {
   func testMatchEmptyClaimPath() {
     let path = ClaimPath([])
     let result = matcher.match(path)
-    XCTAssertNil(result)
+    XCTAssertNotNil(result)
   }
   
   func testMatchRoot() {
     let path = ClaimPath([.claim(name: "")])
     let result = matcher.match(path)
-    XCTAssertNotNil(result)
+    XCTAssertNil(result)
   }
   
   func testMatchBooleanValue() {

--- a/Tests/Presentation/ClaimPathTests.swift
+++ b/Tests/Presentation/ClaimPathTests.swift
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import XCTest
+import SwiftyJSON
+
+@testable import eudi_lib_sdjwt_swift
+
+class ClaimPathTests: XCTestCase {
+  
+  func testClaimPathInitialization() {
+    let path = ClaimPath([.claim(name: "user"), .claim(name: "name")])
+    XCTAssertEqual(path.value, [.claim(name: "user"), .claim(name: "name")])
+  }
+  
+  func testClaimPathAppendingClaim() {
+    let path = ClaimPath.claim("user") + .claim(name: "name")
+    XCTAssertEqual(path, ClaimPath([.claim(name: "user"), .claim(name: "name")]))
+  }
+  
+  func testClaimPathAppendingArrayElement() {
+    let path = ClaimPath.claim("items") + .arrayElement(index: 2)
+    XCTAssertEqual(path, ClaimPath([.claim(name: "items"), .arrayElement(index: 2)]))
+  }
+  
+  func testClaimPathAppendingAllArrayElements() {
+    let path = ClaimPath.claim("items").allArrayElements()
+    XCTAssertEqual(path, ClaimPath([.claim(name: "items"), .allArrayElements]))
+  }
+  
+  func testClaimPathContains() {
+    let parentPath = ClaimPath([.claim(name: "user")])
+    let childPath = ClaimPath([.claim(name: "user"), .claim(name: "name")])
+    XCTAssertTrue(childPath.contains(parentPath))
+    XCTAssertFalse(parentPath.contains(childPath))
+  }
+  
+  func testClaimPathParent() {
+    let path = ClaimPath([.claim(name: "user"), .claim(name: "name")])
+    let parent = path.parent()
+    XCTAssertEqual(parent, ClaimPath([.claim(name: "user")]))
+  }
+  
+  func testClaimPathParentOfRoot() {
+    let path = ClaimPath([.claim(name: "root")])
+    XCTAssertNil(path.parent())
+  }
+  
+  func testClaimPathHead() {
+    let path = ClaimPath([.claim(name: "user"), .claim(name: "name")])
+    XCTAssertEqual(path.head(), .claim(name: "user"))
+  }
+  
+  func testClaimPathTail() {
+    let path = ClaimPath([.claim(name: "user"), .claim(name: "name")])
+    let tail = path.tail()
+    XCTAssertEqual(tail, ClaimPath([.claim(name: "name")]))
+  }
+  
+  func testClaimPathTailOfSingleElement() {
+    let path = ClaimPath([.claim(name: "user")])
+    XCTAssertNil(path.tail())
+  }
+  
+  func testClaimPathJsonPointerInitialization() {
+    let path = ClaimPath(jsonPointer: "/user/name")
+    XCTAssertEqual(path, ClaimPath([.claim(name: "user"), .claim(name: "name")]))
+  }
+  
+  func testClaimPathJsonPointerArrayIndex() {
+    let path = ClaimPath(jsonPointer: "/items/2")
+    XCTAssertEqual(path, ClaimPath([.claim(name: "items"), .arrayElement(index: 2)]))
+  }
+  
+  func testClaimPathJsonPointerEscapedCharacters() {
+    let path = ClaimPath(jsonPointer: "/user~1data")
+    XCTAssertEqual(path, ClaimPath([.claim(name: "user/data")]))
+  }
+  
+  func testClaimPathJsonPointerInvalidFormat() {
+    let path = ClaimPath(jsonPointer: "user/name") // Missing leading "/"
+    XCTAssertNil(path)
+  }
+  
+  func testClaimPathMatches() {
+    let path1 = ClaimPath([.claim(name: "user"), .claim(name: "name")])
+    let path2 = ClaimPath([.claim(name: "user"), .claim(name: "name")])
+    XCTAssertTrue(path1.matches(path2))
+  }
+  
+  func testClaimPathDoesNotMatchDifferentSizes() {
+    let path1 = ClaimPath([.claim(name: "user")])
+    let path2 = ClaimPath([.claim(name: "user"), .claim(name: "name")])
+    XCTAssertFalse(path1.matches(path2))
+  }
+}
+

--- a/Tests/Presentation/PresentationTest.swift
+++ b/Tests/Presentation/PresentationTest.swift
@@ -35,7 +35,7 @@ final class PresentationTest: XCTestCase {
   func testSDJWTPresentationWithSelectiveDisclosures() async throws {
     
     // Given
-    let visitor = Visitor()
+    let visitor = ClaimVisitor()
     let holdersKey = holdersKeyPair.public
     let holdersJwk = try holdersKey.jwk
     let verifier: KeyBindingVerifier = KeyBindingVerifier()
@@ -82,6 +82,9 @@ final class PresentationTest: XCTestCase {
         FlatDisclosedClaim("recursive_address", "東京都港区芝公園４丁目２−８")
       }
       ArrayClaim("evidence", array: [
+        evidenceObject,
+        evidenceObject,
+        evidenceObject,
         evidenceObject
       ])
     }
@@ -149,6 +152,130 @@ final class PresentationTest: XCTestCase {
     
     XCTAssertNotNil(kbJwt)
     XCTAssertEqual(presentedSdJwt.disclosures.count, 5)
+    
+    let presentedDisclosures = Set(presentedSdJwt.disclosures)
+    let visitedDisclosures = Set(visitor.disclosures)
+    XCTAssertTrue(presentedDisclosures.isSubset(of: visitedDisclosures))
+  }
+  
+  func testSDJWTPresentationWithSelectiveDisclosuresUsingClaimPaths() async throws {
+    
+    // Given
+    let visitor = ClaimVisitor()
+    let holdersKey = holdersKeyPair.public
+    let holdersJwk = try holdersKey.jwk
+    let verifier: KeyBindingVerifier = KeyBindingVerifier()
+    
+    @SDJWTBuilder
+    var evidenceObject: SdElement {
+      FlatDisclosedClaim("type", "document")
+      FlatDisclosedClaim("method", "pipp")
+      FlatDisclosedClaim("time", "2012-04-22T11:30Z")
+    }
+    
+    let issuerSignedSDJWT = try await SDJWTIssuer.issue(
+      issuersPrivateKey: issuersKeyPair.private,
+      header: DefaultJWSHeaderImpl(
+        algorithm: .ES256,
+        keyID: "Ao50Swzv_uWu805LcuaTTysu_6GwoqnvJh9rnc44U48"
+      )
+    ) {
+      ConstantClaims.iat(time: Date())
+      ConstantClaims.exp(time: Date() + 3600)
+      ConstantClaims.iss(domain: "https://example.com/issuer")
+      FlatDisclosedClaim("sub", "6c5c0a49-b589-431d-bae7-219122a9ec2c")
+      FlatDisclosedClaim("given_name", "太郎")
+      FlatDisclosedClaim("family_name", "山田")
+      FlatDisclosedClaim("email", "\"unusual email address\"@example.jp")
+      FlatDisclosedClaim("phone_number", "+81-80-1234-5678")
+      ObjectClaim("address") {
+        FlatDisclosedClaim("street_address", "東京都港区芝公園４丁目２−８")
+        FlatDisclosedClaim("locality", "東京都")
+        FlatDisclosedClaim("region", "港区")
+        FlatDisclosedClaim("country", "JP")
+      }
+      FlatDisclosedClaim("birthdate", "1940-01-01")
+      ObjectClaim("cnf") {
+        ObjectClaim("jwk") {
+          PlainClaim("kid", "Ao50Swzv_uWu805LcuaTTysu_6GwoqnvJh9rnc44U48")
+          PlainClaim("kty", "EC")
+          PlainClaim("y", holdersJwk.y!.base64URLEncode())
+          PlainClaim("x", holdersJwk.x!.base64URLEncode())
+          PlainClaim("crv", "P-256")
+        }
+      }
+      RecursiveObject("test_recursive") {
+        FlatDisclosedClaim("recursive_address", "東京都港区芝公園４丁目２−８")
+      }
+      ArrayClaim("evidence", array: [
+        evidenceObject,
+        evidenceObject,
+        evidenceObject,
+        evidenceObject
+      ])
+    }
+    
+    // When
+    let query: Set<ClaimPath> = Set([
+      .claim("address").claim("region"),
+      .claim("address").claim("country"),
+      .claim("test_recursive").claim("recursive_address"),
+      .claim("evidence").arrayElement(0).claim("time"),
+      .claim("evidence").arrayElement(1).claim("method"),
+      ]
+    )
+    
+    let presentedSdJwt = try await issuerSignedSDJWT.present(
+      query: query,
+      visitor: visitor
+    )
+    
+    guard let presentedSdJwt = presentedSdJwt else {
+      XCTFail("Expected presentedSdJwt value to be non-nil but it was nil")
+      return
+    }
+    
+    let sdHash = DigestCreator()
+      .hashAndBase64Encode(
+        input: CompactSerialiser(
+          signedSDJWT: presentedSdJwt
+        ).serialised
+      )!
+    
+    var holderPresentation: SignedSDJWT?
+      holderPresentation = try await SDJWTIssuer
+        .presentation(
+          holdersPrivateKey: TestP256AsyncSigner(secKey: holdersKeyPair.private),
+          signedSDJWT: issuerSignedSDJWT,
+          disclosuresToPresent: presentedSdJwt.disclosures,
+          keyBindingJWT: KBJWT(
+            header: DefaultJWSHeaderImpl(algorithm: .ES256),
+            kbJwtPayload: .init([
+              Keys.nonce.rawValue: "123456789",
+              Keys.aud.rawValue: "example.com",
+              Keys.iat.rawValue: 1694600000,
+              Keys.sdHash.rawValue: sdHash
+            ])
+          )
+        )
+    
+    let kbJwt = holderPresentation?.kbJwt
+    
+    // Then
+    XCTAssertNoThrow(
+      try verifier.verify(
+        iatOffset: .init(
+          startTime: Date(timeIntervalSince1970: 1694600000 - 1000),
+          endTime: Date(timeIntervalSince1970: 1694600000)
+        )!,
+        expectedAudience: "example.com",
+        challenge: kbJwt!,
+        extractedKey: holdersJwk
+      )
+    )
+    
+    XCTAssertNotNil(kbJwt)
+    XCTAssertEqual(presentedSdJwt.disclosures.count, 6)
     
     let presentedDisclosures = Set(presentedSdJwt.disclosures)
     let visitedDisclosures = Set(visitor.disclosures)

--- a/Tests/Presentation/PresentationTest.swift
+++ b/Tests/Presentation/PresentationTest.swift
@@ -141,8 +141,8 @@ final class PresentationTest: XCTestCase {
     XCTAssertNoThrow(
       try verifier.verify(
         iatOffset: .init(
-          startTime: Date(timeIntervalSince1970: 1694600000 - 1000),
-          endTime: Date(timeIntervalSince1970: 1694600000)
+          startTime: Date(timeIntervalSinceNow: -100000),
+          endTime: Date(timeIntervalSinceNow: 100000)
         )!,
         expectedAudience: "example.com",
         challenge: kbJwt!,
@@ -265,8 +265,8 @@ final class PresentationTest: XCTestCase {
     XCTAssertNoThrow(
       try verifier.verify(
         iatOffset: .init(
-          startTime: Date(timeIntervalSince1970: 1694600000 - 1000),
-          endTime: Date(timeIntervalSince1970: 1694600000)
+          startTime: Date(timeIntervalSinceNow: -100000),
+          endTime: Date(timeIntervalSinceNow: 100000)
         )!,
         expectedAudience: "example.com",
         challenge: kbJwt!,

--- a/Tests/Presentation/SelectPathTests.swift
+++ b/Tests/Presentation/SelectPathTests.swift
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import XCTest
+import SwiftyJSON
+
+@testable import eudi_lib_sdjwt_swift
+
+class SelectPathTests: XCTestCase {
+  
+  var selectPath: DefaultSelectPath!
+  
+  override func setUp() {
+    super.setUp()
+    selectPath = DefaultSelectPath()
+  }
+  
+  func testSelectClaimFromDictionary() {
+    let json = JSON(["name": "Alice", "age": 30])
+    let path = ClaimPath([.claim(name: "name")])
+    
+    let result = selectPath.select(json: json, path: path)
+    
+    switch result {
+    case .success(let selectedJSON):
+      XCTAssertEqual(selectedJSON, JSON("Alice"))
+    case .failure:
+      XCTFail("Expected to find 'name' but failed")
+    }
+  }
+  
+  func testSelectNonexistentClaim() {
+    let json = JSON(["name": "Alice"])
+    let path = ClaimPath([.claim(name: "unknown")])
+    
+    let result = selectPath.select(json: json, path: path)
+    
+    switch result {
+    case .success(let selectedJSON):
+      XCTAssertEqual(selectedJSON, JSON.null)
+    case .failure:
+      XCTFail("Expected nil but failed")
+    }
+  }
+  
+  func testSelectFromArrayByIndex() {
+    let json = JSON(["items": ["apple", "banana", "cherry"]])
+    let path = ClaimPath([.claim(name: "items"), .arrayElement(index: 1)])
+    
+    let result = selectPath.select(json: json, path: path)
+    
+    switch result {
+    case .success(let selectedJSON):
+      XCTAssertEqual(selectedJSON, JSON("banana"))
+    case .failure:
+      XCTFail("Expected to find 'banana' but failed")
+    }
+  }
+  
+  func testSelectArrayElementOutOfBounds() {
+    let json = JSON(["items": ["apple", "banana"]])
+    let path = ClaimPath([.claim(name: "items"), .arrayElement(index: 5)]) // Index out of bounds
+    
+    let result = selectPath.select(json: json, path: path)
+    
+    switch result {
+    case .success(let selectedJSON):
+      XCTAssertEqual(selectedJSON, nil)
+    case .failure:
+      XCTFail("Expected nil for out-of-bounds index")
+    }
+  }
+  
+  func testSelectAllArrayElements() {
+    let json = JSON(["items": [["id": 1], ["id": 2], ["id": 3]]])
+    let path = ClaimPath([.claim(name: "items"), .allArrayElements, .claim(name: "id")])
+    
+    let result = selectPath.select(json: json, path: path)
+    
+    switch result {
+    case .success(let selectedJSON):
+      XCTAssertEqual(selectedJSON, JSON([1, 2, 3]))
+    case .failure:
+      XCTFail("Expected [1, 2, 3] but failed")
+    }
+  }
+  
+  func testSelectFromNonDictionary() {
+    let json = JSON(["items": "not a dictionary"])
+    let path = ClaimPath([.claim(name: "items"), .claim(name: "name")]) // Should fail
+    
+    let result = selectPath.select(json: json, path: path)
+    
+    switch result {
+    case .success:
+      XCTFail("Expected failure but got success")
+    case .failure(let error):
+      XCTAssertTrue(error.localizedDescription.contains("Expected JSON object"))
+    }
+  }
+  
+  func testSelectFromNonArray() {
+    let json = JSON(["items": "not an array"])
+    let path = ClaimPath([.claim(name: "items"), .arrayElement(index: 0)]) // Should fail
+    
+    let result = selectPath.select(json: json, path: path)
+    
+    switch result {
+    case .success:
+      XCTFail("Expected failure but got success")
+    case .failure(let error):
+      XCTAssertTrue(error.localizedDescription.contains("Expected JSON array"))
+    }
+  }
+}
+
+

--- a/Tests/Types/SdJwtVcTypeMetadataTests.swift
+++ b/Tests/Types/SdJwtVcTypeMetadataTests.swift
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import XCTest
+import SwiftyJSON
+
+@testable import eudi_lib_sdjwt_swift
+
+final class SdJwtVcTypeMetadataTests: XCTestCase {
+  
+  func testValidSdJwtVcTypeMetadataInitialization() throws {
+    let vct = try SdJwtVcTypeMetadata.Vct(value: "test-vct")
+    
+    let metadata = try SdJwtVcTypeMetadata(
+      vct: vct,
+      name: "Test Name",
+      description: "Test Description"
+    )
+    
+    XCTAssertEqual(metadata.vct.value, "test-vct")
+    XCTAssertEqual(metadata.name, "Test Name")
+    XCTAssertEqual(metadata.description, "Test Description")
+    XCTAssertNil(metadata.schema) // Ensure optional properties default to nil
+  }
+  
+  func testConflictingSchemaThrowsError() {
+    let vct = try! SdJwtVcTypeMetadata.Vct(value: "test-vct")
+    let schema = JSON(["key": "value"])
+    let schemaUri = URL(string: "https://example.com/schema")!
+    
+    XCTAssertThrowsError(
+      try SdJwtVcTypeMetadata(vct: vct, schema: schema, schemaUri: schemaUri)
+    ) { error in
+      XCTAssertEqual(error as? SDJWTError, SDJWTError.error("Conflicting schema definitions"))
+    }
+  }
+  
+  func testVctCannotBeEmpty() {
+    XCTAssertThrowsError(try SdJwtVcTypeMetadata.Vct(value: "")) { error in
+      XCTAssertEqual(error as? SDJWTError, SDJWTError.error("Vct value must not be blank"))
+    }
+  }
+  
+  func testValidClaimMetadataInitialization() {
+    let claimMetadata = SdJwtVcTypeMetadata.ClaimMetadata(
+      path: "user.age",
+      selectivelyDisclosable: .allowed
+    )
+    
+    XCTAssertEqual(claimMetadata.path, "user.age")
+    XCTAssertEqual(claimMetadata.selectivelyDisclosable, .allowed)
+    XCTAssertNil(claimMetadata.display)
+  }
+  
+  func testDisplayCannotHaveDuplicateLanguages() {
+    let displayList = [
+      SdJwtVcTypeMetadata.DisplayMetadata(lang: "en", name: "English"),
+      SdJwtVcTypeMetadata.DisplayMetadata(lang: "en", name: "Duplicate English")
+    ]
+    
+    XCTAssertThrowsError(try SdJwtVcTypeMetadata.Display(value: displayList)) { error in
+      XCTAssertEqual(error as? SDJWTError, SDJWTError.error("Each language must appear only once in the display list"))
+    }
+  }
+  
+  func testValidDisplayMetadataInitialization() {
+    let displayMetadata = SdJwtVcTypeMetadata.DisplayMetadata(
+      lang: "en",
+      name: "Test Name",
+      description: "Test Description"
+    )
+    
+    XCTAssertEqual(displayMetadata.lang, "en")
+    XCTAssertEqual(displayMetadata.name, "Test Name")
+    XCTAssertEqual(displayMetadata.description, "Test Description")
+  }
+  
+  func testSvgTemplatePropertiesThrowsErrorWhenEmpty() {
+    XCTAssertThrowsError(try SdJwtVcTypeMetadata.SvgTemplateProperties()) { error in
+      XCTAssertEqual(error as? SDJWTError, SDJWTError.error("At least one property must be specified"))
+    }
+  }
+  
+  func testValidSvgTemplatePropertiesInitialization() throws {
+    let properties = try SdJwtVcTypeMetadata.SvgTemplateProperties(orientation: "portrait")
+    
+    XCTAssertEqual(properties.orientation, "portrait")
+    XCTAssertNil(properties.colorScheme)
+    XCTAssertNil(properties.contrast)
+  }
+  
+  func testValidSvgTemplateInitialization() throws {
+    let uri = URL(string: "https://example.com/svg")!
+    let integrity = SdJwtVcTypeMetadata.DocumentIntegrity(value: "hash123")
+    let properties = try SdJwtVcTypeMetadata.SvgTemplateProperties(orientation: "landscape")
+    
+    let template = SdJwtVcTypeMetadata.SvgTemplate(uri: uri, uriIntegrity: integrity, properties: properties)
+    
+    XCTAssertEqual(template.uri, uri)
+    XCTAssertEqual(template.uriIntegrity?.value, "hash123")
+    XCTAssertEqual(template.properties?.orientation, "landscape")
+  }
+  
+  func testValidLogoMetadataInitialization() {
+    let uri = URL(string: "https://example.com/logo.png")!
+    let integrity = SdJwtVcTypeMetadata.DocumentIntegrity(value: "hash456")
+    
+    let logoMetadata = SdJwtVcTypeMetadata.LogoMetadata(uri: uri, uriIntegrity: integrity, altText: "Logo Alt Text")
+    
+    XCTAssertEqual(logoMetadata.uri, uri)
+    XCTAssertEqual(logoMetadata.uriIntegrity?.value, "hash456")
+    XCTAssertEqual(logoMetadata.altText, "Logo Alt Text")
+  }
+  
+  func testClaimSelectivelyDisclosableEnum() {
+    XCTAssertEqual(SdJwtVcTypeMetadata.ClaimSelectivelyDisclosable.always.rawValue, "always")
+    XCTAssertEqual(SdJwtVcTypeMetadata.ClaimSelectivelyDisclosable.allowed.rawValue, "allowed")
+    XCTAssertEqual(SdJwtVcTypeMetadata.ClaimSelectivelyDisclosable.never.rawValue, "never")
+  }
+  
+  func testRenderingMetadataInitialization() {
+    let renderingMetadata = SdJwtVcTypeMetadata.RenderingMetadata(simple: nil, svgTemplates: nil)
+    XCTAssertNil(renderingMetadata.simple)
+    XCTAssertNil(renderingMetadata.svgTemplates)
+  }
+  
+  func testDocumentIntegrityInitialization() {
+    let integrity = SdJwtVcTypeMetadata.DocumentIntegrity(value: "integrity-value")
+    XCTAssertEqual(integrity.value, "integrity-value")
+  }
+  
+  func testComplexInitialization() throws {
+    let vct = try SdJwtVcTypeMetadata.Vct(value: "complex-vct")
+    let integrity = SdJwtVcTypeMetadata.DocumentIntegrity(value: "doc-integrity")
+    
+    let displayMetadata = SdJwtVcTypeMetadata.DisplayMetadata(lang: "en", name: "Test Name")
+    let display = try SdJwtVcTypeMetadata.Display(value: [displayMetadata])
+    
+    let schemaJson = JSON(["title": "Test Schema"])
+    
+    let metadata = try SdJwtVcTypeMetadata(
+      vct: vct,
+      vctIntegrity: integrity,
+      name: "Complex Metadata",
+      description: "A more complex test case",
+      extends: URL(string: "https://example.com")!,
+      extendsIntegrity: integrity,
+      display: display,
+      claims: [],
+      schema: schemaJson
+    )
+    
+    XCTAssertEqual(metadata.vct.value, "complex-vct")
+    XCTAssertEqual(metadata.name, "Complex Metadata")
+    XCTAssertEqual(metadata.description, "A more complex test case")
+    XCTAssertEqual(metadata.extendsIntegrity?.value, "doc-integrity")
+    XCTAssertEqual(metadata.display?.value.first?.name, "Test Name")
+  }
+}
+

--- a/Tests/Verification/VcVerifierTest.swift
+++ b/Tests/Verification/VcVerifierTest.swift
@@ -361,6 +361,9 @@ final class VcVerifierTest: XCTestCase {
         ).serialised
       )!
     
+    let nonce = UUID().uuidString
+    let aud = "aud"
+    let timestamp = Int(Date().timeIntervalSince1970.rounded())
     let holder = try await SDJWTIssuer
       .presentation(
         holdersPrivateKey: holdersKeyPair.private,
@@ -369,9 +372,9 @@ final class VcVerifierTest: XCTestCase {
         keyBindingJWT: KBJWT(
           header: DefaultJWSHeaderImpl(algorithm: .ES256),
           kbJwtPayload: .init([
-            Keys.nonce.rawValue: "123456789",
-            Keys.aud.rawValue: "example.com",
-            Keys.iat.rawValue: 1694600000,
+            Keys.nonce.rawValue: nonce,
+            Keys.aud.rawValue: aud,
+            Keys.iat.rawValue: timestamp,
             Keys.sdHash.rawValue: sdHash
           ])
         )

--- a/Tests/Verification/VcVerifierTest.swift
+++ b/Tests/Verification/VcVerifierTest.swift
@@ -50,7 +50,7 @@ final class VcVerifierTest: XCTestCase {
   func testVerifyIssuance_WithValidSDJWT_Withx509Header_PrimaryIssuer_ShouldSucceed() async throws {
     
     // Given
-    let sdJwtString = SDJWTConstants.primary_issuer_sd_jwt.clean()
+    let sdJwtString = SDJWTConstants.secondary_issuer_sd_jwt.clean()
     
     // When
     let result = try await SDJWTVCVerifier(

--- a/Tests/Verification/VerifierTest.swift
+++ b/Tests/Verification/VerifierTest.swift
@@ -339,8 +339,8 @@ final class VerifierTest: XCTestCase {
       let verifier = KeyBindingVerifier()
       try verifier.verify(
         iatOffset: .init(
-          startTime: Date(timeIntervalSince1970: 1694600000 - 1000),
-          endTime: Date(timeIntervalSince1970: 1694600000)
+          startTime: Date(timeIntervalSinceNow: -100000),
+          endTime: Date(timeIntervalSinceNow: 100000)
         )!,
         expectedAudience: "example.com",
         challenge: jws,


### PR DESCRIPTION
# Description of change

This PR implements SD-JWT-VC Type metadata

- [x] Provide a model for Type metadata
- [x] Use `ClaimPath` on `present()`

Closes #49  
Closes #50  

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes