### PR TITLE
[fix] ad_alg is optiona

### DIFF
--- a/.github/workflows/build-eudi-lib-sdjwt-swift.yml
+++ b/.github/workflows/build-eudi-lib-sdjwt-swift.yml
@@ -4,8 +4,7 @@
     pull_request:
       types: [opened, reopened]
     push:
-      branches: ['main']
-      tags: [ v* ]
+  
   jobs:
     build:
       runs-on: "macos-14"

--- a/Sources/Issuer/SDJWT.swift
+++ b/Sources/Issuer/SDJWT.swift
@@ -42,16 +42,12 @@ public struct SDJWT {
   }
   
   func extractDigestCreator() throws -> DigestCreator {
-    if jwt.payload[Keys.sdAlg.rawValue].exists() {
-      let stringValue = jwt.payload[Keys.sdAlg.rawValue].stringValue
-      let algorithIdentifier = HashingAlgorithmIdentifier.allCases.first(where: {$0.rawValue == stringValue})
-      guard let algorithIdentifier else {
-        throw SDJWTVerifierError.missingOrUnknownHashingAlgorithm
-      }
-      return DigestCreator(hashingAlgorithm: algorithIdentifier.hashingAlgorithm())
-    } else {
+    let sdAlg = jwt.payload[Keys.sdAlg.rawValue].string ?? "sha-256"
+    let algorithIdentifier = HashingAlgorithmIdentifier.allCases.first(where: {$0.rawValue == sdAlg})
+    guard let algorithIdentifier else {
       throw SDJWTVerifierError.missingOrUnknownHashingAlgorithm
     }
+    return DigestCreator(hashingAlgorithm: algorithIdentifier.hashingAlgorithm())
   }
   
   func recreateClaims(visitor: ClaimVisitor? = nil) throws -> ClaimExtractorResult {


### PR DESCRIPTION
# Description of change

`_sd_alg` is now optional according to the [specification](https://www.ietf.org/archive/id/draft-ietf-oauth-selective-disclosure-jwt-22.html#hash_function_claim)

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [ ] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes