### PR TITLE
Metadata verification policy

### DIFF
--- a/Sources/TypeMetadata/TypeMetadataPolicy.swift
+++ b/Sources/TypeMetadata/TypeMetadataPolicy.swift
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// Defines a Verifier's policy concerning Type Metadata.
+public enum TypeMetadataPolicy {
+  
+  /**
+   * Type Metadata are not used.
+   */
+  case notUsed
+  
+  /**
+   * Type Metadata are not required.
+   * Failure to successfully resolve Type Metadata for any Vct, does not result in the rejection of the SD-JWT VC.
+   */
+  case optional(verifier: TypeMetadataVerifierType)
+  
+  /**
+   * Type Metadata are always required for all Vcts.
+   * Failure to successfully resolve Type Metadata for any Vct, results in the rejection of the SD-JWT VC.
+   */
+  case alwaysRequired(verifier: TypeMetadataVerifierType)
+  
+  /**
+   * Type Metadata are always required for the specified Vcts.
+   * Failure to successfully resolve Type Metadata for any of the specified Vcts, results in the rejection of the SD-JWT VC.
+   */
+  case requiredFor(vcts: Set<String>, verifier: TypeMetadataVerifierType)
+}

--- a/Sources/TypeMetadata/Vct.swift
+++ b/Sources/TypeMetadata/Vct.swift
@@ -15,7 +15,7 @@
  */
 
 
-public struct Vct {
+public struct Vct: Hashable {
   public let uri: String
   public var integrityHash: String? = nil
   


### PR DESCRIPTION
Introduces a policy-based approach to type metadata verification, allowing for different verification requirements.

This change introduces a `TypeMetadataPolicy` enum to define how type metadata is handled during SD-JWT VC verification. The policy can be set to not use type metadata, make it optional, require it always, or require it for specific VCTs.

# Description of change

This change replaces the simple optional TypeMetadataVerifier with a `TypeMetadataPolicy` enum, allowing for more fine
grained control over when Type Metadata verification is performed. The policy can be set to `.notUsed`, `.optional`,
`.alwaysRequired`, or `.requiredFor` specific VCTs.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Address the issue #71 