### PR TITLE
Overrides parent claim metadata with child's

### DIFF
--- a/Sources/TypeMetadata/TypeMetadataMerger.swift
+++ b/Sources/TypeMetadata/TypeMetadataMerger.swift
@@ -25,6 +25,9 @@ package protocol TypeMetadataMergerType {
    *
    * The merging process prioritizes the properties of the first element in the array,
    * using subsequent elements to fill in missing values or merge collections.
+   *
+   * If a child type defines claim metadata with the same path as
+   * in the extended type, the child type's claim metadata will fully override the parent's.
    */
   func mergeMetadata(from metadataArray: [ResolvedTypeMetadata]) -> ResolvedTypeMetadata?
 }
@@ -53,19 +56,7 @@ struct TypeMetadataMerger: TypeMetadataMergerType {
         primary: result.claims,
         secondary: parent.claims,
         keySelector: \.path,
-        merge: { current, parent in
-          SdJwtVcTypeMetadata.ClaimMetadata(
-            path: current.path,
-            display: mergeByKey(
-              primary: current.display ?? [],
-              secondary: parent.display ?? [],
-              keySelector: \.lang,
-              merge: { current, _ in current }
-            ),
-            selectivelyDisclosable: current.selectivelyDisclosable,
-            svgId: current.svgId
-          )
-        }
+        merge: { current, _ in current }  
       )
       
       return ResolvedTypeMetadata(
@@ -123,5 +114,3 @@ struct TypeMetadataMerger: TypeMetadataMergerType {
     return merged
   }
 }
-
-


### PR DESCRIPTION
Per SD-JWT VC Draft 11, when a child type defines claim metadata with the same path as its parent, the child's metadata fully overrides the parent's.

Addresses #87 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [ ] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes