### PR TITLE
Validates against disclosing registered claims

### DIFF
--- a/Sources/TypeMetadata/DisclosureValidator.swift
+++ b/Sources/TypeMetadata/DisclosureValidator.swift
@@ -47,6 +47,16 @@ struct DisclosureValidator: DisclosureValidatorType {
       throw TypeMetadataError.missingDisclosuresForValidation
     }
     
+    
+    for (claimPath, disclosureList) in disclosures {
+      if let claimName = claimPath.leafClaimName,
+         SdJwtSpec.registeredNonDisclosableClaims.contains(claimName) {
+        if !disclosureList.isEmpty {
+          throw TypeMetadataError.unexpectedDisclosurePresent(path: claimPath)
+        }
+      }
+    }
+    
     for claim in metadata.claims {
       
       let claimPath = claim.path

--- a/Sources/Types/Spec.swift
+++ b/Sources/Types/Spec.swift
@@ -48,6 +48,17 @@ struct SdJwtSpec {
   static let mediaSubtypeKBJWT = "kb+jwt"
   static let mediaTypeApplicationKBJWTJSON = "application/\(mediaSubtypeKBJWT)"
   static let suffixSDJWT = "+sd-jwt"
+  
+  static let registeredNonDisclosableClaims: Set<String> =
+  [
+    "iss",
+    "nbf",
+    "exp",
+    "cnf",
+    "vct",
+    "vct#integrity",
+    "status"
+  ]
 }
 
 /// JSON Web Signature (JWS) Specification

--- a/Sources/Utilities/ClaimPath.swift
+++ b/Sources/Utilities/ClaimPath.swift
@@ -182,3 +182,15 @@ extension ClaimPath: Decodable {
     self.init(elements)
   }
 }
+
+
+extension ClaimPath {
+  /// Returns the last claim name if available.
+  var leafClaimName: String? {
+    value.last?.fold(
+      ifAllArrayElements: { nil },
+      ifArrayElement: { _ in nil },
+      ifClaim: { $0 }
+    )
+  }
+}

--- a/Tests/TypeMetadata/DisclosedValidatorTests.swift
+++ b/Tests/TypeMetadata/DisclosedValidatorTests.swift
@@ -135,4 +135,20 @@ final class DisclosedValidatorTests: XCTestCase {
     // When/Then
     XCTAssertNoThrow(try sut.validate(metadata, disclosures))
   }
+  
+  func testValidate_registeredClaimDisclosurePresent_throwsError() {
+   
+    // Registered claim that must NOT be disclosed (e.g. "vct#integrity")
+    let claimPath = ClaimPath([.claim(name: "vct#integrity")])
+    let disclosures: DisclosuresPerClaimPath = [claimPath: ["someDisclosureValue"]]
+    let metadata = ResolvedTypeMetadata(vct: "vct", claims: [])
+    
+    let sut = DisclosureValidator()
+    
+    // When / Then
+    XCTAssertThrowsError(try sut.validate(metadata, disclosures)) { error in
+      // The validator should flag the unexpected disclosure for a registered claim
+      XCTAssertEqual(error as? TypeMetadataError, .unexpectedDisclosurePresent(path: claimPath))
+    }
+  }
 }


### PR DESCRIPTION
Adds validation to prevent the disclosure of registered claims (e.g., "iss", "exp", "cnf") within SD-JWTs.

These claims are intended to be non-disclosable according to the specification. The change introduces a check during disclosure validation to ensure that registered claims are not present in the disclosures, throwing an error if found.

Addresses: #86 

# Description of change

Please include a summary of the change and what is fixed or updated. 
Please also include relevant motivation and context. 
List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [ ] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes