### PR TITLE
Change SAST action workflow to use Swift version

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -9,7 +9,7 @@ on:
 jobs:
 
    SAST_caller:
-      uses: eu-digital-identity-wallet/eudi-infra-ci/.github/workflows/sast_action.yml@main
+      uses: eu-digital-identity-wallet/eudi-infra-ci/.github/workflows/sast_action_swift.yml@main
       secrets:
        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description of change

Update the SAST GitHub Action reference to the latest Swift action, which introduces built-in support for code coverage reporting