### PR TITLE
Exposes Type Metadata components

### DIFF
--- a/Sources/TypeMetadata/TypeMetadataLookupDefault.swift
+++ b/Sources/TypeMetadata/TypeMetadataLookupDefault.swift
@@ -34,7 +34,7 @@ public protocol TypeMetadataLookup {
   ) async throws -> [SdJwtVcTypeMetadata]
 }
 
-struct TypeMetadataLookupDefault: TypeMetadataLookup {
+public struct TypeMetadataLookupDefault: TypeMetadataLookup {
   
   let fetcher: TypeMetadataFetching
   
@@ -44,7 +44,7 @@ struct TypeMetadataLookupDefault: TypeMetadataLookup {
     self.fetcher = fetcher
   }
   
-  func getTypeMetadata(vct: Vct) async throws -> [SdJwtVcTypeMetadata] {
+  public func getTypeMetadata(vct: Vct) async throws -> [SdJwtVcTypeMetadata] {
     
     guard let vctURL = URL(string: vct.uri) else {
       throw TypeMetadataError.invalidTypeMetadataURL

--- a/Sources/TypeMetadata/TypeMetadataMerger.swift
+++ b/Sources/TypeMetadata/TypeMetadataMerger.swift
@@ -39,7 +39,7 @@ public protocol TypeMetadataMergerType {
    func mergeMetadata(from metadataArray: [ResolvedTypeMetadata]) throws -> ResolvedTypeMetadata?
 }
 
-struct TypeMetadataMerger: TypeMetadataMergerType {
+public struct TypeMetadataMerger: TypeMetadataMergerType {
   
   public func mergeMetadata(
     from metadataArray: [ResolvedTypeMetadata]


### PR DESCRIPTION
# Description of change

Makes `TypeMetadataLookupDefault` and `TypeMetadataMerger` public.
This change allows external access and usage of these components, facilitating greater flexibility and customization.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes