### PR TITLE
Enforce unique disclosure digests across nested SD-JWT structures

### DIFF
--- a/Sources/Utilities/DigestCollector.swift
+++ b/Sources/Utilities/DigestCollector.swift
@@ -48,16 +48,84 @@ enum DigestCollector {
     return digests
   }
 
-  /// Recursively collects digests from JSON structure
+  /// Collects all digests from a JSON payload AND from nested structures within disclosures
+  ///
+  /// This method opens each disclosure to check if it contains nested JSON structures
+  /// with additional `_sd` arrays, ensuring all digests (including nested ones) are found.
+  ///
+  /// - Parameters:
+  ///   - json: The JWT payload to search
+  ///   - disclosures: Map of digests to their corresponding disclosures
+  /// - Returns: Array of all digest strings found (including nested within disclosures)
+  ///
+  static func collectAll(from json: JSON, disclosures: [DisclosureDigest: Disclosure]) -> [DisclosureDigest] {
+    var digests: [DisclosureDigest] = []
+    var processedDigests: Set<DisclosureDigest> = [] // Track to avoid infinite loops
+    collectDigestsRecursively(from: json, disclosures: disclosures, into: &digests, processed: &processedDigests)
+    return digests
+  }
+
+  /// Recursively collects digests from JSON structure (without using disclosures)
   ///
   /// - Parameters:
   ///   - json: The JSON to search
   ///   - digests: Mutable array to collect digests into
   private static func collectDigestsRecursively(from json: JSON, into digests: inout [DisclosureDigest]) {
+    var emptyProcessed = Set<DisclosureDigest>()
+    collectDigestsRecursively(from: json, disclosures: [:], into: &digests, processed: &emptyProcessed)
+  }
+
+  /// Recursively collects digests from JSON structure, opening disclosures to find nested digests
+  ///
+  /// This method ensures RFC 9901 compliance by finding ALL digests, including those
+  /// hidden within disclosed values. When a digest is found, it looks up the corresponding
+  /// disclosure and recursively searches it for additional `_sd` arrays.
+  ///
+  /// - Parameters:
+  ///   - json: The JSON to search
+  ///   - disclosures: Map of digests to disclosures for opening nested structures
+  ///   - digests: Mutable array to collect digests into
+  ///   - processed: Set of already-processed digests to avoid infinite loops
+  ///
+  private static func collectDigestsRecursively(
+    from json: JSON,
+    disclosures: [DisclosureDigest: Disclosure],
+    into digests: inout [DisclosureDigest],
+    processed: inout Set<DisclosureDigest>
+  ) {
     // Collect from _sd array at this level
     if let sdArray = json[Keys.sd.rawValue].array {
       let digestStrings = sdArray.compactMap { $0.string }
       digests.append(contentsOf: digestStrings)
+
+      // For each digest, check if we can open the disclosure to find nested _sd arrays
+      for digest in digestStrings {
+        // Avoid infinite loops by tracking processed digests
+        guard !processed.contains(digest) else { continue }
+        processed.insert(digest)
+
+        // Try to decode the disclosure for this digest
+        if let disclosure = disclosures[digest],
+           let decodedString = disclosure.base64URLDecode(),
+           let disclosureArray = try? JSON(parseJSON: decodedString).arrayValue,
+           disclosureArray.count >= 2 {
+
+          // The disclosure format is [salt, claim_name, claim_value] for objects
+          // or [salt, claim_value] for array elements
+          let valueIndex = disclosureArray.count - 1
+          let claimValue = disclosureArray[valueIndex]
+
+          // If the disclosed value is a JSON object or array, recursively search it
+          if claimValue.type == .dictionary || claimValue.type == .array {
+            collectDigestsRecursively(
+              from: claimValue,
+              disclosures: disclosures,
+              into: &digests,
+              processed: &processed
+            )
+          }
+        }
+      }
     }
 
     // Recursively search in nested objects
@@ -72,7 +140,12 @@ enum DigestCollector {
 
         // Recurse into nested objects
         if subJson.type == .dictionary {
-          collectDigestsRecursively(from: subJson, into: &digests)
+          collectDigestsRecursively(
+            from: subJson,
+            disclosures: disclosures,
+            into: &digests,
+            processed: &processed
+          )
         }
 
         // Recurse into arrays
@@ -81,11 +154,38 @@ enum DigestCollector {
             // Check for array element digest (... syntax)
             if let dotDigest = arrayElement[Keys.dots.rawValue].string {
               digests.append(dotDigest)
+
+              // Open this array element disclosure to check for nested _sd arrays
+              guard !processed.contains(dotDigest) else { continue }
+              processed.insert(dotDigest)
+
+              if let disclosure = disclosures[dotDigest],
+                 let decodedString = disclosure.base64URLDecode(),
+                 let disclosureArray = try? JSON(parseJSON: decodedString).arrayValue,
+                 disclosureArray.count >= 2 {
+
+                let valueIndex = disclosureArray.count - 1
+                let claimValue = disclosureArray[valueIndex]
+
+                if claimValue.type == .dictionary || claimValue.type == .array {
+                  collectDigestsRecursively(
+                    from: claimValue,
+                    disclosures: disclosures,
+                    into: &digests,
+                    processed: &processed
+                  )
+                }
+              }
             }
 
             // Recurse into nested objects/arrays within array
             if arrayElement.type == .dictionary || arrayElement.type == .array {
-              collectDigestsRecursively(from: arrayElement, into: &digests)
+              collectDigestsRecursively(
+                from: arrayElement,
+                disclosures: disclosures,
+                into: &digests,
+                processed: &processed
+              )
             }
           }
         }
@@ -116,6 +216,21 @@ enum DigestCollector {
   /// ```
   static func validateUniqueness(in json: JSON) throws {
     let allDigests = collectAll(from: json)
+    try ensureUnique(allDigests)
+  }
+
+  /// Collects and validates uniqueness of all digests, including those hidden in disclosures
+  ///
+  /// This method is opening disclosures
+  /// to find nested `_sd` arrays that may contain duplicate digests.
+  ///
+  /// - Parameters:
+  ///   - json: The JWT payload to validate
+  ///   - disclosures: Map of digests to disclosures for opening nested structures
+  /// - Throws: `SDJWTVerifierError.nonUniqueDisclosureDigests` if duplicates found
+  ///
+  static func validateUniqueness(in json: JSON, disclosures: [DisclosureDigest: Disclosure]) throws {
+    let allDigests = collectAll(from: json, disclosures: disclosures)
     try ensureUnique(allDigests)
   }
 }

--- a/Sources/Verifier/DisclosuresVerifier.swift
+++ b/Sources/Verifier/DisclosuresVerifier.swift
@@ -56,6 +56,8 @@ public final class DisclosuresVerifier: VerifierProtocol {
     }
     digestsOfDisclosuresDict = dict
     
+    try DigestCollector.validateUniqueness(in: sdJwt.jwt.payload, disclosures: digestsOfDisclosuresDict)
+
     let claimExtractor =
     try ClaimExtractor(
       digestsOfDisclosuresDict: digestsOfDisclosuresDict
@@ -72,12 +74,6 @@ public final class DisclosuresVerifier: VerifierProtocol {
   // MARK: - Methods
   @discardableResult
   public func verify() throws -> DisclosuresVerifierOutput {
-    // Ensure digest uniqueness
-    // Check recreated claims which includes:
-    // - All digests from original JWT payload
-    // - Digests from nested structures revealed by disclosures
-    try DigestCollector.validateUniqueness(in: recreatedClaims)
-
     // Create the digest for the provided disclosures
     // Convert the base64 string to the hash, Digests we got passed
     // Base64 [salt, key, value]

--- a/Tests/Utilities/DigestCollectorTest.swift
+++ b/Tests/Utilities/DigestCollectorTest.swift
@@ -240,4 +240,207 @@ final class DigestCollectorTest: XCTestCase {
     XCTAssertTrue(digests.contains("nat_digest1"))
     XCTAssertTrue(digests.contains("nat_digest2"))
   }
+
+  // MARK: - Disclosure-Aware Collection Tests
+
+  func testCollectAllWithDisclosures_NoNesting_CollectsSameAsBasic() {
+    // Simple case: disclosures don't contain nested _sd arrays
+    let json = JSON([
+      "_sd": ["digest1", "digest2"]
+    ])
+
+    // Disclosures reveal simple values, not nested structures
+    let disclosures: [DisclosureDigest: Disclosure] = [
+      "digest1": createDisclosure(salt: "salt1", key: "name", value: "Alice"),
+      "digest2": createDisclosure(salt: "salt2", key: "age", value: 30)
+    ]
+
+    let digests = DigestCollector.collectAll(from: json, disclosures: disclosures)
+    XCTAssertEqual(digests.count, 2, "Should collect both digests")
+    XCTAssertTrue(digests.contains("digest1"))
+    XCTAssertTrue(digests.contains("digest2"))
+  }
+
+  func testCollectAllWithDisclosures_NestedObject_FindsNestedDigests() {
+    // Disclosure reveals an object with nested _sd array
+    let json = JSON([
+      "_sd": ["digest1"]
+    ])
+
+    let disclosures: [DisclosureDigest: Disclosure] = [
+      "digest1": createDisclosure(salt: "salt1", key: "address", value: [
+        "_sd": ["nested_digest1", "nested_digest2"],
+        "country": "US"
+      ])
+    ]
+
+    let digests = DigestCollector.collectAll(from: json, disclosures: disclosures)
+    XCTAssertEqual(digests.count, 3, "Should find digest1 + 2 nested digests")
+    XCTAssertTrue(digests.contains("digest1"))
+    XCTAssertTrue(digests.contains("nested_digest1"))
+    XCTAssertTrue(digests.contains("nested_digest2"))
+  }
+
+  func testCollectAllWithDisclosures_DuplicateInNested_FindsDuplicate() {
+    // This is the security issue: same digest appears in top-level and nested
+    let json = JSON([
+      "_sd": ["digest_A", "digest_B"]
+    ])
+
+    // disclosure_A reveals an object that ALSO contains digest_B
+    let disclosures: [DisclosureDigest: Disclosure] = [
+      "digest_A": createDisclosure(salt: "salt1", key: "nested", value: [
+        "_sd": ["digest_B"],  // DUPLICATE!
+        "data": "value"
+      ])
+    ]
+
+    let digests = DigestCollector.collectAll(from: json, disclosures: disclosures)
+
+    // Should find: digest_A (top), digest_B (top), digest_B (nested) = 3 total, 2 unique
+    XCTAssertEqual(digests.count, 3, "Should collect all 3 digest occurrences")
+    XCTAssertTrue(digests.contains("digest_A"))
+    XCTAssertTrue(digests.contains("digest_B"))
+
+    // Verify uniqueness check would fail
+    XCTAssertThrowsError(try DigestCollector.ensureUnique(digests)) { error in
+      guard case SDJWTVerifierError.nonUniqueDisclosureDigests = error else {
+        XCTFail("Expected nonUniqueDisclosureDigests error")
+        return
+      }
+    }
+  }
+
+  func testValidateUniquenessWithDisclosures_DuplicateInNested_Throws() {
+    let json = JSON([
+      "_sd": ["digest_A", "digest_B"]
+    ])
+
+    let disclosures: [DisclosureDigest: Disclosure] = [
+      "digest_A": createDisclosure(salt: "salt1", key: "nested", value: [
+        "_sd": ["digest_B"]  // DUPLICATE!
+      ])
+    ]
+
+    XCTAssertThrowsError(try DigestCollector.validateUniqueness(in: json, disclosures: disclosures)) { error in
+      guard case SDJWTVerifierError.nonUniqueDisclosureDigests = error else {
+        XCTFail("Expected nonUniqueDisclosureDigests error, got \(error)")
+        return
+      }
+    }
+  }
+
+  func testCollectAllWithDisclosures_DeeplyNested_FindsAll() {
+    // Test multiple levels of nesting
+    let json = JSON([
+      "_sd": ["level1_digest"]
+    ])
+
+    let disclosures: [DisclosureDigest: Disclosure] = [
+      "level1_digest": createDisclosure(salt: "s1", key: "level1", value: [
+        "_sd": ["level2_digest"],
+        "data": "value"
+      ]),
+      "level2_digest": createDisclosure(salt: "s2", key: "level2", value: [
+        "_sd": ["level3_digest"]
+      ]),
+      "level3_digest": createDisclosure(salt: "s3", key: "level3", value: "final_value")
+    ]
+
+    let digests = DigestCollector.collectAll(from: json, disclosures: disclosures)
+    XCTAssertEqual(digests.count, 3, "Should find all 3 levels of digests")
+    XCTAssertTrue(digests.contains("level1_digest"))
+    XCTAssertTrue(digests.contains("level2_digest"))
+    XCTAssertTrue(digests.contains("level3_digest"))
+  }
+
+  func testCollectAllWithDisclosures_ArrayElement_FindsNestedDigests() {
+    // Test array element disclosure containing _sd array
+    let json = JSON([
+      "array": [
+        ["...": "array_digest1"]
+      ]
+    ])
+
+    let disclosures: [DisclosureDigest: Disclosure] = [
+      "array_digest1": createArrayDisclosure(salt: "salt1", value: [
+        "_sd": ["nested_in_array"],
+        "item": "data"
+      ])
+    ]
+
+    let digests = DigestCollector.collectAll(from: json, disclosures: disclosures)
+    XCTAssertEqual(digests.count, 2, "Should find array digest + nested digest")
+    XCTAssertTrue(digests.contains("array_digest1"))
+    XCTAssertTrue(digests.contains("nested_in_array"))
+  }
+
+  func testCollectAllWithDisclosures_CircularReference_AvoidInfiniteLoop() {
+    // Edge case: ensure we don't infinite loop if somehow digests reference each other
+    let json = JSON([
+      "_sd": ["digest_A"]
+    ])
+
+    // This is an invalid scenario, but we should handle it gracefully
+    let disclosures: [DisclosureDigest: Disclosure] = [
+      "digest_A": createDisclosure(salt: "s1", key: "field", value: [
+        "_sd": ["digest_A"]  // Self-reference (invalid but shouldn't crash)
+      ])
+    ]
+
+    let digests = DigestCollector.collectAll(from: json, disclosures: disclosures)
+    // Should collect digest_A twice but not loop forever
+    XCTAssertTrue(digests.count >= 1, "Should collect at least one digest")
+    XCTAssertTrue(digests.contains("digest_A"))
+  }
+
+  func testCollectAllWithDisclosures_MultipleNestedSameDigest_FindsAll() {
+    // Multiple different top-level digests reveal the same nested digest
+    let json = JSON([
+      "_sd": ["digest_A", "digest_B"]
+    ])
+
+    let disclosures: [DisclosureDigest: Disclosure] = [
+      "digest_A": createDisclosure(salt: "s1", key: "field1", value: [
+        "_sd": ["shared_digest"]
+      ]),
+      "digest_B": createDisclosure(salt: "s2", key: "field2", value: [
+        "_sd": ["shared_digest"]  // Same nested digest!
+      ])
+    ]
+
+    let digests = DigestCollector.collectAll(from: json, disclosures: disclosures)
+    // Should find: digest_A, digest_B, shared_digest (from A), shared_digest (from B) = 4 total
+    XCTAssertEqual(digests.count, 4, "Should collect all occurrences")
+
+    // Verify uniqueness check fails
+    XCTAssertThrowsError(try DigestCollector.ensureUnique(digests))
+  }
+
+  // MARK: - Helper Methods
+
+  /// Creates a base64-encoded disclosure for an object property
+  private func createDisclosure(salt: String, key: String, value: Any) -> Disclosure {
+    let array = [salt, key, value]
+    let jsonData = try! JSONSerialization.data(withJSONObject: array)
+    return jsonData.base64URLEncode()
+  }
+
+  /// Creates a base64-encoded disclosure for an array element
+  private func createArrayDisclosure(salt: String, value: Any) -> Disclosure {
+    let array = [salt, value]
+    let jsonData = try! JSONSerialization.data(withJSONObject: array)
+    return jsonData.base64URLEncode()
+  }
+}
+
+extension Data {
+  /// Base64URL encoding helper for tests
+  func base64URLEncode() -> String {
+    let base64 = self.base64EncodedString()
+    return base64
+      .replacingOccurrences(of: "+", with: "-")
+      .replacingOccurrences(of: "/", with: "_")
+      .replacingOccurrences(of: "=", with: "")
+  }
 }


### PR DESCRIPTION
Issue: PR #136 partially addressed RFC 9901 Section 7.1 Step 4, but missed duplicates hidden in nested disclosures.

Root Causes
- Timing: Checked after claims reconstruction (when _sd arrays already removed)
- Incomplete scanning: Didn't open disclosures to find nested _sd arrays

Updates `DigestCollector` to recursively search within disclosures for nested `_sd` arrays and array element references. This ensures all digest values are unique throughout the entire SD-JWT, as required by the specification. Validation in `DisclosuresVerifier` has been moved to occur earlier during initialization using the full set of available disclosures.

# Description of change

Please include a summary of the change and what is fixed or updated. 
Please also include relevant motivation and context. 
List any dependencies that are required for this change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Closes: #147 